### PR TITLE
Get rid of `@generated` for NormalFormGame(payoffs::Array)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat 0.8.4

--- a/src/Games.jl
+++ b/src/Games.jl
@@ -6,8 +6,9 @@ module Games
 typealias PureAction Integer
 typealias MixedAction{T<:Real} Vector{T}
 typealias Action{T<:Real} Union{PureAction,MixedAction{T}}
-typealias ActionProfile{T<:Real,N} NTuple{N,Action{T}}
 typealias PureActionProfile{N,T<:PureAction} NTuple{N, T}
+typealias MixedActionProfile{T<:Real,N} NTuple{N,MixedAction{T}}
+typealias ActionProfile Union{PureActionProfile,MixedActionProfile}
 
 # package code goes here
 include("normal_form_game.jl")

--- a/src/Games.jl
+++ b/src/Games.jl
@@ -2,6 +2,9 @@ module Games
 
 # Packages
 
+# 0.5 compatibility
+import Compat.view
+
 # Type aliases #
 typealias PureAction Integer
 typealias MixedAction{T<:Real} Vector{T}

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -19,9 +19,8 @@ const opponents_actions_docstring = """
 opponents' actions. If N=2, then it must be a vector of reals (in which case
 it is treated as the opponent's mixed action) or a scalar of integer (in which
 case it is treated as the opponent's pure action). If N>2, then it must be a
-tuple of N-1 objects, where each object must be an integer (pure action) or a
-vector of reals (mixed action). (For the degenerate case N=1, it must be
-`nothing`.)"""
+tuple of N-1 integers (pure actions) or N-1 vectors of reals (mixed actions).
+(For the degenerate case N=1, it must be `nothing`.)"""
 
 
 # Player #
@@ -571,8 +570,8 @@ Return true if `action_profile` is a Nash equilibrium.
 ##### Arguments
 
 - `g::NormalFormGame` : Instance of N-player NormalFormGame.
-- `action_profile::ActionProfile` : Tuple of N objects, where each object must
-be an integer (pure action) or a vector of reals (mixed action).
+- `action_profile::ActionProfile` : Tuple of N integers (pure actions) or N
+vectors of reals (mixed actions).
 
 ##### Returns
 

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -460,7 +460,7 @@ function NormalFormGame{T<:Real,M}(payoffs::Array{T,M})
     dims = front(size(payoffs))
     colons = front(ntuple(j -> Colon(), M)::NTuple{M,Colon})
     players = [
-        Player(permutedims(sub(payoffs, colons..., i),
+        Player(permutedims(view(payoffs, colons..., i),
                            (i:N..., 1:i-1...)::typeof(dims))
         ) for i in 1:N
     ]

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -452,13 +452,14 @@ Constructor of an N-player NormalFormGame.
 """
 function NormalFormGame{T<:Real,M}(payoffs::Array{T,M})
     N = M - 1
+    dims = front(size(payoffs))
+    colons = front(ntuple(j -> Colon(), M)::NTuple{M,Colon})
+
     size(payoffs)[end] != N && throw(ArgumentError(
         "length of the array in the last axis must be equal to
          the number of players"
     ))
 
-    dims = front(size(payoffs))
-    colons = front(ntuple(j -> Colon(), M)::NTuple{M,Colon})
     players = [
         Player(permutedims(view(payoffs, colons..., i),
                            (i:N..., 1:i-1...)::typeof(dims))

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -43,7 +43,7 @@ type Player{N,T<:Real}
     payoff_array::Array{T,N}
 end
 
-num_actions(p::Player) = size(p.payoff_array)[1]
+num_actions(p::Player) = size(p.payoff_array, 1)
 num_opponents{N}(::Player{N}) = N - 1
 
 Base.summary(player::Player) =

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -214,7 +214,7 @@ valse otherwise.
 """
 function is_best_response(player::Player,
                           own_action::PureAction,
-                          opponents_actions::Union{Action,PureActionProfile,MixedActionProfile,Void};
+                          opponents_actions::Union{Action,ActionProfile,Void};
                           tol::Float64=1e-8)
     payoffs = payoff_vector(player, opponents_actions)
     payoff_max = maximum(payoffs)
@@ -239,7 +239,7 @@ false otherwise.
 """
 function is_best_response(player::Player,
                           own_action::MixedAction,
-                          opponents_actions::Union{Action,PureActionProfile,MixedActionProfile,Void};
+                          opponents_actions::Union{Action,ActionProfile,Void};
                           tol::Float64=1e-8)
     payoffs = payoff_vector(player, opponents_actions)
     payoff_max = maximum(payoffs)
@@ -264,7 +264,7 @@ actions.
 
 """
 function best_responses(player::Player,
-                        opponents_actions::Union{Action,PureActionProfile,MixedActionProfile,Void};
+                        opponents_actions::Union{Action,ActionProfile,Void};
                         tol::Float64=1e-8)
     payoffs = payoff_vector(player, opponents_actions)
     payoff_max = maximum(payoffs)
@@ -291,7 +291,7 @@ from the best response actions.
 
 """
 function best_response(player::Player,
-                       opponents_actions::Union{Action,PureActionProfile,MixedActionProfile,Void};
+                       opponents_actions::Union{Action,ActionProfile,Void};
                        tie_breaking::AbstractString="smallest",
                        tol::Float64=1e-8)
     if tie_breaking == "smallest"
@@ -325,7 +325,7 @@ payoffs in determining the best response.
 
 """
 function best_response(player::Player,
-                       opponents_actions::Union{Action,PureActionProfile,MixedActionProfile,Void},
+                       opponents_actions::Union{Action,ActionProfile,Void},
                        payoff_perturbation::Vector{Float64})
     length(payoff_perturbation) != num_actions(player) &&
         throw(ArgumentError(

--- a/test/test_normal_form_game.jl
+++ b/test/test_normal_form_game.jl
@@ -40,9 +40,10 @@
         @test @inferred(payoff_vector(player, (1, 2))) == [6, 0]
         @test !(@inferred(is_best_response(player, 1, (2, 1))))
         @test @inferred(best_response(player, (2, 2))) == 2
-        @test @inferred(best_response(player, (1, [1/2, 1/2]))) == 1
         @test sort(@inferred(best_responses(player, ([3/7, 4/7], [1/2, 1/2])))) ==
               sort([1, 2])
+
+        @test_throws MethodError best_response(player, (1, [1/2, 1/2]))
     end
 
     @testset "symmetric NormalFormGame with 2 players" begin


### PR DESCRIPTION
By using [`Base.front`](https://github.com/JuliaLang/julia/commit/61836ca3a83750759e0fdeaabc377cb65a01bd17#diff-fd99c9a15dadc23d9200069dadafb8bb) introduced in v0.5.

Address https://github.com/QuantEcon/Games.jl/issues/2#issue-141102799.
