### PR TITLE
Add random game generators

### DIFF
--- a/src/Games.jl
+++ b/src/Games.jl
@@ -4,6 +4,7 @@ module Games
 using Clp
 using MathProgBase
 using QuantEcon
+using Distributions
 
 # Geometry packages
 using Polyhedra
@@ -22,6 +23,7 @@ include("normal_form_game.jl")
 include("pure_nash.jl")
 include("repeated_game_util.jl")
 include("repeated_game.jl")
+include("random.jl")
 
 
 export
@@ -45,6 +47,9 @@ export
     RepeatedGame, unpack, flow_u_1, flow_u_2, flow_u, best_dev_i,
     best_dev_1, best_dev_2, best_dev_payoff_i, best_dev_payoff_1,
     best_dev_payoff_2, worst_value_i, worst_value_1, worst_value_2,
-    worst_values, outerapproximation
+    worst_values, outerapproximation,
+
+    # Random Games
+    random_game, covariance_game
 
 end # module

--- a/src/random.jl
+++ b/src/random.jl
@@ -1,0 +1,80 @@
+#=
+Generate random NormalFormGame instances.
+=#
+
+#
+# Random Games Generating
+#
+"""
+    random_game{N}(nums_actions::NTuple{N,Int})
+
+Return a random NormalFormGame instance where the payoffs are drawn
+independently from the uniform distribution on [0, 1).
+
+# Arguements
+* `nums_actions::NTuple{N,Int}`: Tuple of the numbers of actions,
+    one for each player.
+
+# Returns
+* `::NormalFormGame`: The generated N-players random NormalFormGame.
+"""
+function random_game{N}(nums_actions::NTuple{N,Int})
+    if N == 0
+        throw(ArgumentError("nums_actions must be non-empty"))
+    end
+
+    players::NTuple{N,Player{N,Float64}} =
+        ntuple(i -> Player(rand(tuple(nums_actions[i:end]...,
+                                      nums_actions[1:i-1]...))),
+               N)
+
+    return NormalFormGame(players)
+end
+
+#
+# Covariance Games Generating
+#
+"""
+    covariance_game{N, T<:Real}(nums_actions::NTuple{N,Int}, rho::T)
+
+Return a random NormalFormGame instance where the payoff profiles
+are drawn independently from the standard multi-normal with the
+covariance of any pair of payoffs equal to `rho`, as studied in
+[1]_.
+
+# Arguements
+* `nums_actions::NTuple{N,Int}`: Tuple of the numbers of actions, 
+    one for each　player.
+* `rho::T`: Covariance of a pair of payoff values. Must be in
+    [-1/(N-1), 1], where N is the number of players. T<:Real.
+
+# Returns
+* `::NormalFormGame`: The generated random NormalFormGame.
+
+# References
+1. Y. Rinott and M. Scarsini, "On the Number of Pure Strategy
+   Nash Equilibria in Random Games," Games and Economic Behavior
+   (2000), 274-293.
+"""
+function covariance_game{N, T<:Real}(nums_actions::NTuple{N,Int}, rho::T)
+    if N <= 1
+        throw(ArgumentError("length of nums_actions must be at least 2"))
+    end
+
+    if !(-1 / (N - 1) < rho < 1)
+        lb = (N == 2) ? "-1" : "-1/$(N-1)"
+        throw(ArgumentError("rho must be in ($lb, 1)"))
+    end
+
+    mu = zeros(N)
+    C = fill(rho, (N, N))
+    C[diagind(C)] = ones(N)
+
+    d = MvNormal(mu, C)
+    x = rand(d, prod(nums_actions))
+
+    payoff_profile_array =
+        reshape(transpose(x), (nums_actions..., N))
+
+    return NormalFormGame(payoff_profile_array)
+end

--- a/src/random.jl
+++ b/src/random.jl
@@ -1,5 +1,7 @@
 #=
 Generate random NormalFormGame instances.
+
+Authors: Daisuke Oyama, Zejin Shi
 =#
 
 #
@@ -8,15 +10,18 @@ Generate random NormalFormGame instances.
 """
     random_game{N}(nums_actions::NTuple{N,Int})
 
-Return a random NormalFormGame instance where the payoffs are drawn
-independently from the uniform distribution on [0, 1).
+Return a random N-player NormalFormGame instance where the
+payoffs are drawn independently from the uniform distribution
+on [0, 1).
 
 # Arguements
+
 * `nums_actions::NTuple{N,Int}`: Tuple of the numbers of actions,
-    one for each player.
+  one for each player.
 
 # Returns
-* `::NormalFormGame`: The generated N-players random NormalFormGame.
+
+* `::NormalFormGame`: The generated random N-player NormalFormGame.
 """
 function random_game{N}(nums_actions::NTuple{N,Int})
     if N == 0
@@ -35,28 +40,31 @@ end
 # Covariance Games Generating
 #
 """
-    covariance_game{N, T<:Real}(nums_actions::NTuple{N,Int}, rho::T)
+    covariance_game{N}(nums_actions::NTuple{N,Int}, rho::Real)
 
-Return a random NormalFormGame instance where the payoff profiles
-are drawn independently from the standard multi-normal with the
-covariance of any pair of payoffs equal to `rho`, as studied in
-[1]_.
+Return a random N-player NormalFormGame instance with N>=2 where
+the payoff profiles are drawn independently from the standard
+multi-normal with the covariance of any pair of payoffs equal to
+`rho`, as studied in Rinott and Scarsini (2000).
 
 # Arguements
+
 * `nums_actions::NTuple{N,Int}`: Tuple of the numbers of actions, 
-    one for each　player.
+  one for each　player.
 * `rho::T`: Covariance of a pair of payoff values. Must be in
-    [-1/(N-1), 1], where N is the number of players. T<:Real.
+  [-1/(N-1), 1], where N is the number of players.
 
 # Returns
-* `::NormalFormGame`: The generated random NormalFormGame.
+
+* `::NormalFormGame`: The generated random N-player NormalFormGame.
 
 # References
-1. Y. Rinott and M. Scarsini, "On the Number of Pure Strategy
-   Nash Equilibria in Random Games," Games and Economic Behavior
-   (2000), 274-293.
+
+* Y. Rinott and M. Scarsini, "On the Number of Pure Strategy
+  Nash Equilibria in Random Games," Games and Economic Behavior
+  (2000), 274-293.
 """
-function covariance_game{N, T<:Real}(nums_actions::NTuple{N,Int}, rho::T)
+function covariance_game{N}(nums_actions::NTuple{N,Int}, rho::Real)
     if N <= 1
         throw(ArgumentError("length of nums_actions must be at least 2"))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using Base.Test
 include("test_pure_nash.jl")
 include("test_repeated_game.jl")
 include("test_normal_form_game.jl")
+include("test_random.jl")

--- a/test/test_random.jl
+++ b/test/test_random.jl
@@ -1,0 +1,47 @@
+@testset "Testing Random Games Generating" begin
+
+    @testset "test random game" begin
+        nums_actions = (2, 3, 4)
+        g = random_game(nums_actions)
+
+        @test g.nums_actions == nums_actions
+    end
+
+    @testset "test covariance game" begin
+        nums_actions = (2, 3, 4)
+
+        rho = 0.5
+        g = covariance_game(nums_actions, rho)
+        @test g.nums_actions == nums_actions
+
+    end
+
+    @testset "test random game value error" begin
+        nums_actions = ()
+
+        @test_throws ArgumentError random_game(nums_actions)
+
+    end
+
+    @testset "test covariance game value error" begin
+        nums_actions = () #empty
+
+        @test_throws ArgumentError covariance_game(nums_actions, 0.5)
+
+        nums_actions = (2,) #length one
+
+        @test_throws ArgumentError covariance_game(nums_actions, 0.5)
+
+        nums_actions = (2, 3, 4)
+        rho = 1.1 # > 1
+
+        @test_throws ArgumentError covariance_game(nums_actions, rho)
+
+        rho = -1. # < -1/(N-1)
+
+        @test_throws ArgumentError covariance_game(nums_actions, rho)
+
+    end
+
+
+end


### PR DESCRIPTION
closes #20 
Translation of ["random.py"](https://github.com/QuantEcon/QuantEcon.py/pull/270).
`seed` option is omitted here, as setting seed locally is not supported by "Distribution.jl".