### PR TITLE
WIP: Add docs using Documenter.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+docs/build/
+docs/site/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
   - nightly
 matrix:
   allow_failures:
@@ -18,3 +18,6 @@ notifications:
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("Games"); Pkg.test("Games"; coverage=true)'
+after_success:
+  - julia -e 'Pkg.add("Documenter")'
+  - julia -e 'cd(Pkg.dir("Games")); include(joinpath("docs", "make.jl"))'

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,15 @@ $julia make.jl
 ```
 
 The generated docs can be accessed in `build/index.html`.
+
+You may modify `Structure` to arrange the structure of the website to be generated. For example:
+
+```
+Order: normal_form_game, Computing Nash equilibria, Repeated Game
+Computing Nash equilibria: pure_nash, support_enumeration
+Repeated Game: repeated_game_util, repeated_game
+```
+
+The first line sets the order of pages. You can add a file name if you want it to generate a single page, or the name of section you want to create. In the following you need to declare which files are included in each section. Note that you shouldn't put a comma or dot at the end of each line.
+
+It is not necessary to declare structure for every file included in the Module. Files not mentioned in `Structure` will simply generate a single page automatically.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+## Generate docs automatically
+
+Run
+```
+$julia make.jl
+```
+
+The generated docs can be accessed in `build/index.html`.

--- a/docs/Structure
+++ b/docs/Structure
@@ -1,0 +1,3 @@
+Order: normal_form_game, Computing Nash Equilibria, Repeated Game
+Computing Nash Equilibria: pure_nash
+Repeated Game: repeated_game_util, repeated_game

--- a/docs/auto_doc_gen.jl
+++ b/docs/auto_doc_gen.jl
@@ -20,8 +20,8 @@ end
 # create PAGES for makedocs()
 PAGES = ["Home" => "index.md",
          "Library" => push!(
-                        Any["lib/$file.md" for file in files],
-                            "lib/index.md"
+                        ["lib/$file.md" for file in files],
+                         "lib/index.md"
                         )
          ]
 

--- a/docs/auto_doc_gen.jl
+++ b/docs/auto_doc_gen.jl
@@ -1,0 +1,96 @@
+#=
+Generate markdown files automatically, for generating
+docs using `Documenter.jl`.
+
+@author: Zejin Shi
+
+=#
+
+# find all files used in Games.jl
+re = r"include\(\"(.*)\.jl\"\)"
+files = String[]
+path = Pkg.dir("Games")
+
+open(joinpath(path, "src/Games.jl")) do f
+    for match in eachmatch(re, readstring(f))
+        push!(files, match.captures[1])
+    end
+end
+
+# create PAGES for makedocs()
+PAGES = ["Home" => "index.md",
+         "Library" => push!(
+                        Any["lib/$file.md" for file in files],
+                            "lib/index.md"
+                        )
+         ]
+
+# generate paths
+if !ispath(joinpath(path, "docs/src/lib"))
+    mkpath(joinpath(path, "docs/src/lib"))
+end
+
+# write index.md as Homepage
+home_page = """
+# Games.jl
+
+"""
+
+open(joinpath(path, "docs/src/index.md"), "w") do f
+    write(f, home_page)
+    for file in files
+        file_name = 
+            replace(join(map(ucfirst, split(file, "_")), " "),
+                    "Util",
+                    "Utilities"
+                )
+        write(f, "* [$file_name](@ref)\n")
+    end
+end
+
+# write .md for each file in Library
+for file in files
+    file_name = 
+            replace(join(map(ucfirst, split(file, "_")), " "),
+                    "Util",
+                    "Utilities"
+                )
+
+    file_page = """
+# $file_name
+
+This is documentation for `$file.jl`.
+
+## Exported
+
+```@autodocs
+Modules = [Games]
+Pages   = ["$file.jl"]
+Private = false
+```
+
+## Internal
+
+```@autodocs
+Modules = [Games]
+Pages   = ["$file.jl"]
+Public = false
+```
+"""
+    open(joinpath(path, "docs/src/lib/$file.md"), "w") do f
+        write(f, file_page)
+    end
+end
+
+# write index page for Liabrary
+index = """
+# Index
+
+```@index
+modules = [Games]
+```
+"""
+
+open(joinpath(path, "docs/src/lib/index.md"), "w") do f
+    write(f, index)
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,10 @@
+using Documenter, Games
+
+include("auto_doc_gen.jl")
+
+makedocs(
+    modules = [Games],
+    format = :html,
+    sitename = "Games.jl",
+    pages = PAGES,
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,3 +8,13 @@ makedocs(
     sitename = "Games.jl",
     pages = PAGES,
 )
+
+deploydocs(
+    repo = "github.com/QuantEcon/Games.jl.git",
+    branch = "gh-pages",
+    target = "build",
+    osname = "osx",
+    julia  = "0.5",
+    deps = nothing,
+    make = nothing,
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,7 @@ deploydocs(
     repo = "github.com/QuantEcon/Games.jl.git",
     branch = "gh-pages",
     target = "build",
-    osname = "osx",
+    osname = "linux",
     julia  = "0.5",
     deps = nothing,
     make = nothing,


### PR DESCRIPTION
Suggested by #25 and QuantEcon/QuantEcon.jl#136 .

Here I wrote a script "auto_doc_gen.jl" to generate markdown files which is needed for Documenter.jl to create docs. It reads `src/Games.jl` and finds out which Julia files are included in it, and then write makrdown file for each respectively. 

I also tried auto-deployment through Travis, following [Hosting Documentation](https://juliadocs.github.io/Documenter.jl/stable/man/hosting.html) and what @sglyon did in QuantEcon.jl. [Here](https://shizejin.github.io/Games.jl/latest/index.html) is what I auto-deployed on my forked repo, so you can see how the output will look like. Especially, I modified docstrings of one [Method](https://shizejin.github.io/Games.jl/latest/lib/normal_form_game.html#Games.NormalFormGame-Tuple{Type,Tuple{Vararg{Int64,N}}}) of NormalFormGame to the format suggested by [Julia](http://docs.julialang.org/en/stable/manual/documentation/), and we can compare with our currently used doctrisngs, to see whether we would like to adopt this style. (This change is only in my forked repo, no in this PR).

One problem happens, that tests for Games.jl can not pass, which causes build on Travis to fail and nothing is pushed to repo by Documenter.jl. For now I disenabled tests "test_normal_form_game.jl" and "test_repeated_game.jl" in my forked repo to avoid build failure, while I don't think it's a good way.

In details:
1. For "test_normal_form_game.jl", failures happen as discussed in #2 .
2. For "test_repeated_game.jl", build errors of CDDLib.jl happens on linux. For osx, it's fine.

It would be great if you would like to give some comments or suggestions.
@oyamad @sglyon @cc7768 