### PR TITLE
FIX: Specialize return type of support_enumeration

### DIFF
--- a/src/support_enumeration.jl
+++ b/src/support_enumeration.jl
@@ -26,20 +26,20 @@ minus 1 such pairs. This should thus be used only for small games.
 
 # Arguments
 
-- `g::NormalFormGame{2}`: 2-player NormalFormGame instance.
+- `g::NormalFormGame{2,T}`: 2-player NormalFormGame instance.
 
 # Returns
 
-- `::Vector{NTuple{2,Vector{Real}}}`: Mixed-action Nash equilibria that are
-  found.
+- `::Vector{NTuple{2,Vector{S}}}`: Mixed-action Nash equilibria that are found,
+  where `S` is Float if `T` is Int or Float, and Rational if `T` is Rational.
 """
-function support_enumeration(g::NormalFormGame{2})
-
-    c = Channel(0)
+function support_enumeration(g::NormalFormGame{2,T}) where T
+    S = typeof(zero(T)/one(T))
+    c = Channel{Tuple{Vector{S},Vector{S}}}(0)
     task = support_enumeration_task(c, g)
     bind(c, task)
     schedule(task)
-    NEs = Tuple{Vector{Real}, Vector{Real}}[NE for NE in c]
+    NEs = collect(c)
 
     return NEs
 

--- a/test/test_support_enumeration.jl
+++ b/test/test_support_enumeration.jl
@@ -6,8 +6,8 @@
         NEs = [([1.0, 0.0, 0.0], [1.0, 0.0]),
                ([0.8, 0.2, 0.0], [2/3, 1/3]),
                ([0.0, 1/3, 2/3], [1/3, 2/3])]
-        
-        for (actions_computed, actions) in zip(NEs, support_enumeration(g))
+
+        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: AbstractFloat
@@ -22,7 +22,7 @@
                ([0.8, 0.2, 0.0], [2/3, 1/3]),
                ([0.0, 1/3, 2/3], [1/3, 2/3])]
 
-        for (actions_computed, actions) in zip(NEs, support_enumeration(g))
+        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: AbstractFloat
@@ -37,7 +37,7 @@
                ([4//5, 1//5, 0//1], [2//3, 1//3]),
                ([0//1, 1//3, 2//3], [1//3, 2//3])]
 
-        for (actions_computed, actions) in zip(NEs, support_enumeration(g))
+        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: Rational
@@ -51,7 +51,7 @@
         NEs = [([1.0, 0.0, 0.0], [1.0, 0.0]),
                ([0.0, 1.0, 0.0], [0.0, 1.0])]
 
-        for (actions_computed, actions) in zip(NEs, support_enumeration(g))
+        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: AbstractFloat
@@ -65,7 +65,7 @@
         NEs = [([1.0, 0.0, 0.0], [1.0, 0.0]),
                ([0.0, 1.0, 0.0], [0.0, 1.0])]
 
-        for (actions_computed, actions) in zip(NEs, support_enumeration(g))
+        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: AbstractFloat
@@ -79,7 +79,7 @@
         NEs = [([1//1, 0//1, 0//1], [1//1, 0//1]),
                ([0//1, 1//1, 0//1], [0//1, 1//1])]
 
-        for (actions_computed, actions) in zip(NEs, support_enumeration(g))
+        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: Rational

--- a/test/test_support_enumeration.jl
+++ b/test/test_support_enumeration.jl
@@ -6,8 +6,9 @@
         NEs = [([1.0, 0.0, 0.0], [1.0, 0.0]),
                ([0.8, 0.2, 0.0], [2/3, 1/3]),
                ([0.0, 1/3, 2/3], [1/3, 2/3])]
+        NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
+        for (actions_computed, actions) in zip(NEs_computed, NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: AbstractFloat
@@ -21,8 +22,9 @@
         NEs = [([1.0, 0.0, 0.0], [1.0, 0.0]),
                ([0.8, 0.2, 0.0], [2/3, 1/3]),
                ([0.0, 1/3, 2/3], [1/3, 2/3])]
+        NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
+        for (actions_computed, actions) in zip(NEs_computed, NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: AbstractFloat
@@ -36,8 +38,9 @@
         NEs = [([1//1, 0//1, 0//1], [1//1, 0//1]),
                ([4//5, 1//5, 0//1], [2//3, 1//3]),
                ([0//1, 1//3, 2//3], [1//3, 2//3])]
+        NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
+        for (actions_computed, actions) in zip(NEs_computed, NEs)
             for (action_computed, action) in zip(actions_computed, actions)
                 @test action_computed ≈ action
                 @test eltype(action_computed) <: Rational


### PR DESCRIPTION
Close #63 

Also found a bug in `test_support_enumeration`:

```jl
for (actions_computed, actions) in zip(NEs, support_enumeration(g))
```

has been corrected to

```jl
for (actions_computed, actions) in zip(support_enumeration(g), NEs)
```