### PR TITLE
Benchmarks with PkgBenchmark.jl & Improvements in support_enumeration

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,74 @@
+# Games.jl Benchmarks
+
+## Running the benchmark suite
+
+Use [PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl):
+
+```jl
+using PkgBenchmark
+```
+
+As an example, let us run the benchmarks (defined in `benchmarks.jl`) and compare the performance changes for the two commits
+[`68f3c4b`](https://github.com/QuantEcon/Games.jl/commit/68f3c4bef03554a00384350a047f1e95abd865df) (target)
+and
+[`d6682de`](https://github.com/QuantEcon/Games.jl/commit/d6682deb9fdae6f16a89b17fbeee9061d763710a) (baseline):
+
+```jl
+jud = judge("Games", "68f3c4b", "d6682de")
+```
+
+To show the results:
+
+```jl
+julia> showall(PkgBenchmark.benchmarkgroup(jud))
+1-element BenchmarkTools.BenchmarkGroup:
+  tags: []
+  "support_enumeration" => 2-element BenchmarkTools.BenchmarkGroup:
+	  tags: ["support_enumeration"]
+	  "Rational" => 2-element BenchmarkTools.BenchmarkGroup:
+		  tags: []
+		  "(8, 8)" => TrialJudgement(-1.86% => invariant)
+		  "(7, 7)" => TrialJudgement(-1.68% => invariant)
+	  "Float" => 2-element BenchmarkTools.BenchmarkGroup:
+		  tags: []
+		  "(10, 10)" => TrialJudgement(-8.62% => improvement)
+		  "(11, 11)" => TrialJudgement(-10.96% => improvement)
+```
+
+To show the timing estimates for the baseline:
+
+```jl
+julia> showall(jud.baseline_results.benchmarkgroup)
+1-element BenchmarkTools.BenchmarkGroup:
+  tags: []
+  "support_enumeration" => 2-element BenchmarkTools.BenchmarkGroup:
+	  tags: ["support_enumeration"]
+	  "Rational" => 2-element BenchmarkTools.BenchmarkGroup:
+		  tags: []
+		  "(8, 8)" => Trial(442.854 ms)
+		  "(7, 7)" => Trial(97.427 ms)
+	  "Float" => 2-element BenchmarkTools.BenchmarkGroup:
+		  tags: []
+		  "(10, 10)" => Trial(207.076 ms)
+		  "(11, 11)" => Trial(867.757 ms)
+```
+
+and for the target:
+
+```jl
+julia> showall(jud.target_results.benchmarkgroup)
+1-element BenchmarkTools.BenchmarkGroup:
+  tags: []
+  "support_enumeration" => 2-element BenchmarkTools.BenchmarkGroup:
+	  tags: ["support_enumeration"]
+	  "Rational" => 2-element BenchmarkTools.BenchmarkGroup:
+		  tags: []
+		  "(8, 8)" => Trial(434.614 ms)
+		  "(7, 7)" => Trial(95.789 ms)
+	  "Float" => 2-element BenchmarkTools.BenchmarkGroup:
+		  tags: []
+		  "(10, 10)" => Trial(189.223 ms)
+		  "(11, 11)" => Trial(772.689 ms)
+```
+
+For more usage information, see the [PkgBenchmark documentation](https://juliaci.github.io/PkgBenchmark.jl/stable).

--- a/benchmark/REQUIRE
+++ b/benchmark/REQUIRE
@@ -1,0 +1,1 @@
+BenchmarkTools

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,25 @@
+using Games
+using BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+SUITE["support_enumeration"] = BenchmarkGroup(["support_enumeration"])
+SUITE["support_enumeration"]["Float"] = BenchmarkGroup()
+seed = 0
+rng = MersenneTwister(seed)
+ns = [10, 11]
+for n in ns
+    sz = (n, n)
+    g = random_game(rng, sz)
+    SUITE["support_enumeration"]["Float"][sz] =
+        @benchmarkable support_enumeration($g)
+end
+SUITE["support_enumeration"]["Rational"] = BenchmarkGroup()
+T = Rational{Int}
+ns = [7, 8]
+for n in ns
+    sz = (n, n)
+    g = NormalFormGame(eye(T, n))
+    SUITE["support_enumeration"]["Rational"][sz] =
+        @benchmarkable support_enumeration($g)
+end

--- a/src/support_enumeration.jl
+++ b/src/support_enumeration.jl
@@ -141,13 +141,17 @@ steps.
 
 # Arguments
 
-- `A::Matrix{T}`: Matrix used in intermediate steps, where `T<:Real`.
-- `b::Vector{T}`: Vector used in intermediate steps, where `T<:Real`.
-- `out::Vector{T}`: Vector to store the nonzero values of the
+- `A::Matrix{T}`: Matrix of shape (k+1, k+1) used in intermediate steps, where
+  `T<:Real`.
+- `b::Vector{T}`: Vector of length k+1 used in intermediate steps, where
+  `T<:Real`.
+- `out::Vector{T}`: Vector of length k to store the nonzero values of the
   desired mixed action, where `T<:Real`.
-- `payoff_matrix::Matrix`: The player's payoff matrix.
-- `own_supp::Vector{Int}`: Vector containing the player's action indices.
-- `opp_supp::Vector{Int}`: Vector containing the opponent's action indices.
+- `payoff_matrix::Matrix`: The player's payoff matrix, of shape (m, n).
+- `own_supp::Vector{Int}`: Vector containing the player's action indices, of
+  length k.
+- `opp_supp::Vector{Int}`: Vector containing the opponent's action indices, of
+  length k.
 
 # Returns
 
@@ -162,7 +166,9 @@ function _indiff_mixed_action!(A::Matrix{T}, b::Vector{T},
     m = size(payoff_matrix, 1)
     k = length(own_supp)
 
-    A[1:end-1, 1:end-1] = payoff_matrix[own_supp, opp_supp]
+    for j in 1:k, i in 1:k
+        A[i, j] = payoff_matrix[own_supp[i], opp_supp[j]]
+    end
     A[1:end-1, end] = -one(T)
     A[end, 1:end-1] = one(T)
     A[end, end] = zero(T)

--- a/test/test_support_enumeration.jl
+++ b/test/test_support_enumeration.jl
@@ -1,5 +1,16 @@
 @testset "Testing Support Enumeration" begin
 
+    function NEs_approx_equal(NEs1::Vector{NTuple{2,Vector{T1}}},
+                              NEs2::Vector{NTuple{2,Vector{T2}}}) where {T1,T2}
+        @test length(NEs1) == length(NEs2)
+        @test T1 == T2
+        for (actions1, actions2) in zip(NEs1, NEs2)
+            for (action1, action2) in zip(actions1, actions2)
+                @test action1 ≈ action2
+            end
+        end
+    end
+
     @testset "test 3 by 2 non-degenerate normal form game(Float)" begin
         g = NormalFormGame(Player([3.0 3.0; 2.0 5.0; 0.0 6.0]),
                            Player([3.0 2.0 3.0; 2.0 6.0 1.0]))
@@ -8,12 +19,7 @@
                ([0.0, 1/3, 2/3], [1/3, 2/3])]
         NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(NEs_computed, NEs)
-            for (action_computed, action) in zip(actions_computed, actions)
-                @test action_computed ≈ action
-                @test eltype(action_computed) <: AbstractFloat
-            end
-        end
+        NEs_approx_equal(NEs_computed, NEs)
     end
 
     @testset "test 3 by 2 non-degenerate normal form game(Int)" begin
@@ -24,12 +30,7 @@
                ([0.0, 1/3, 2/3], [1/3, 2/3])]
         NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(NEs_computed, NEs)
-            for (action_computed, action) in zip(actions_computed, actions)
-                @test action_computed ≈ action
-                @test eltype(action_computed) <: AbstractFloat
-            end
-        end
+        NEs_approx_equal(NEs_computed, NEs)
     end
 
     @testset "test 3 by 2 non-degenerate normal form game(Rational)" begin
@@ -40,12 +41,7 @@
                ([0//1, 1//3, 2//3], [1//3, 2//3])]
         NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(NEs_computed, NEs)
-            for (action_computed, action) in zip(actions_computed, actions)
-                @test action_computed ≈ action
-                @test eltype(action_computed) <: Rational
-            end
-        end
+        NEs_approx_equal(NEs_computed, NEs)
     end
 
     @testset "test 3 by 2 degenerate normal form game(Float)" begin
@@ -53,13 +49,9 @@
                            Player([1.0 0.0 0.0; 0.0 0.0 0.0]))
         NEs = [([1.0, 0.0, 0.0], [1.0, 0.0]),
                ([0.0, 1.0, 0.0], [0.0, 1.0])]
+        NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
-            for (action_computed, action) in zip(actions_computed, actions)
-                @test action_computed ≈ action
-                @test eltype(action_computed) <: AbstractFloat
-            end
-        end
+        NEs_approx_equal(NEs_computed, NEs)
     end
 
     @testset "test 3 by 2 degenerate normal form game(Int)" begin
@@ -67,13 +59,9 @@
                            Player([1 0 0; 0 0 0]))
         NEs = [([1.0, 0.0, 0.0], [1.0, 0.0]),
                ([0.0, 1.0, 0.0], [0.0, 1.0])]
+        NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
-            for (action_computed, action) in zip(actions_computed, actions)
-                @test action_computed ≈ action
-                @test eltype(action_computed) <: AbstractFloat
-            end
-        end
+        NEs_approx_equal(NEs_computed, NEs)
     end
 
     @testset "test 3 by 2 degenerate normal form game(Rational)" begin
@@ -81,14 +69,9 @@
                            Player([1//1 0//1 0//1; 0//1 0//1 0//1]))
         NEs = [([1//1, 0//1, 0//1], [1//1, 0//1]),
                ([0//1, 1//1, 0//1], [0//1, 1//1])]
+        NEs_computed = @inferred(support_enumeration(g))
 
-        for (actions_computed, actions) in zip(support_enumeration(g), NEs)
-            for (action_computed, action) in zip(actions_computed, actions)
-                @test action_computed ≈ action
-                @test eltype(action_computed) <: Rational
-            end
-        end
+        NEs_approx_equal(NEs_computed, NEs)
     end
-
 
 end


### PR DESCRIPTION
* Add benchmarking framework using [PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl)
* Refactor `support_enumeration` for performance improvement
  Now the speed is almost the same as the Python version.

- [x] Add manual about how to run the benchmark suite