### PR TITLE
Use QuantEcon.next_k_array! in support_enumeration

### DIFF
--- a/src/support_enumeration.jl
+++ b/src/support_enumeration.jl
@@ -118,9 +118,9 @@ function _support_enumeration_producer(c::Channel,
                         put!(c, out)
                     end
                 end
-                _next_k_array!(supps[2])
+                next_k_array!(supps[2])
             end
-            _next_k_array!(supps[1])
+            next_k_array!(supps[1])
         end
     end
 


### PR DESCRIPTION
Closes Issue #70

All the changes have been made similar to https://github.com/QuantEcon/QuantEcon.py/commit/a215f1f41d312d555b9b2de719ec379bcd16156d