### PR TITLE
FIX: Workaround for type instability in 0.6

### DIFF
--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -187,7 +187,7 @@ for (S, ex_mat_action) in ((PureAction, :(A[:, action])),
     @eval function _reduce_ith_opponent(payoff_array::Array{T,N},
                                         i::Int, action::$S) where {N,T}
         shape = size(payoff_array)
-        A = reshape(payoff_array, (prod(shape[1:i]), shape[i+1]))
+        A = reshape(payoff_array, (prod(shape[1:i]), shape[i+1]))::Matrix{T}
         out = $(ex_mat_action)
         shape_new = tuple(shape[1:i]..., ones(Int, N-i)...)::NTuple{N,Int}
         return reshape(out, shape_new)


### PR DESCRIPTION
Some `@inferred` tests in `test_normal_form_game.jl` fail after an update of `Clp.jl` to v0.5.0.

* Errors occur if `include("test_normal_form_game.jl")` is executed *after* `include("test_repeated_game.jl")`.

In fact, a couple of `ANY`s show up with:

```jl
using Games

pd_payoff = [9.0 1.0
             10.0 3.0]
A = Player(pd_payoff)
B = Player(pd_payoff)
nfg = NormalFormGame((A, B))
rpd = RepeatedGame(nfg, 0.75)
vertices = outerapproximation(rpd; nH=32, maxiter=150, tol=1e-9)

player = Player(zeros(2, 2, 2))
payoffs = player.payoff_array
i = 2
opponents_actions = (1, 2)
@code_warntype Games._reduce_ith_opponent(payoffs, i, opponents_actions[I])
```

This PR resolves this issue by a type annotation.