### PR TITLE
DOC: turn `prettyurls` off.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ include("auto_doc_gen.jl")
 
 makedocs(
     modules = [Games],
-    format = :html,
+    format = Documenter.HTML(prettyurls = false),
     sitename = "Games.jl",
     pages = PAGES,
 )


### PR DESCRIPTION
Update `Documenter.makedocs` keywords and set `prettyurls` off.