### PR TITLE
is_dominated: Use MathOptInterface in place of MathProgBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,6 @@ Combinatorics
 Parameters
 MathProgBase
 MathOptInterface
-JuMP
 Clp
 Polyhedra
 LightGraphs

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,10 @@
 julia 0.7
-Clp
-MathProgBase
 QuantEcon
-Polyhedra
-LightGraphs
 Combinatorics
 Parameters
+MathProgBase
+MathOptInterface
+JuMP
+Clp
+Polyhedra
+LightGraphs

--- a/src/Games.jl
+++ b/src/Games.jl
@@ -12,7 +12,6 @@ using Parameters
 using MathProgBase
 using MathOptInterface
 const MOI = MathOptInterface
-using JuMP
 using Clp
 
 # Geometry packages

--- a/src/Games.jl
+++ b/src/Games.jl
@@ -4,11 +4,16 @@ module Games
 using LinearAlgebra, Random
 
 # Packages
-using Clp
-using MathProgBase
 using QuantEcon
 using Combinatorics
 using Parameters
+
+# Optimization packages
+using MathProgBase
+using MathOptInterface
+const MOI = MathOptInterface
+using JuMP
+using Clp
 
 # Geometry packages
 using Polyhedra

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -847,7 +847,8 @@ Return true if `action_profile` is Pareto dominant for game `g`.
 # is_dominated
 
 """
-    is_dominated(player, action; tol=1e-8, lp_solver=ClpSolver())
+    is_dominated(player, action; tol=1e-8,
+                 lp_solver=JuMP.with_optimizer(Clp.Optimizer, LogLevel=0))
 
 Determine whether `action` is strictly dominated by some mixed action.
 
@@ -855,11 +856,10 @@ Determine whether `action` is strictly dominated by some mixed action.
 
 - `player::Player` : Player instance.
 - `action::PureAction` : Integer representing a pure action.
-- `tol::Real` : Tolerance to be used.
-- `lp_solver::AbstractMathProgSolver` : Allows users to choose a particular
-  solver for linear programming problems. Options include ClpSolver(),
-  CbcSolver(), GLPKSolverLP() and GurobiSolver(). By default, it choooses
-  ClpSolver().
+- `tol::Real` : Tolerance level used in determining domination.
+- `lp_solver::JuMP.OptimizerFactory` : Linear programming solver to be used
+  internally. For default, `JuMP.with_optimizer(Clp.Optimizer, LogLevel=0)` is
+  passed.
 
 # Returns
 
@@ -867,61 +867,84 @@ Determine whether `action` is strictly dominated by some mixed action.
   otherwise.
 
 """
-function is_dominated(player::Player{N,T}, action::PureAction;
-                      tol::Real=1e-8,
-                      lp_solver::MathProgBase.AbstractMathProgSolver=
-                      ClpSolver()) where {N,T<:Real}
+function is_dominated(::Type{T}, player::Player, action::PureAction;
+                      tol::Real=1e-8, lp_solver::OptimizerFactory=
+                      with_optimizer(Clp.Optimizer, LogLevel=0)) where T<:Real
     payoff_array = player.payoff_array
-    S = typeof(zero(T)/one(T))
-
-    m, n = size(payoff_array, 1) - 1, prod(size(player.payoff_array)[2:end])
+    m, n = size(payoff_array, 1) - 1, prod(size(payoff_array)[2:end])
 
     ind = trues(num_actions(player))
     ind[action] = false
 
-    A = Array{S}(undef, n+1, m+1)
-    A[1:n, 1:m] = transpose(reshape(-selectdim(payoff_array, 1, ind) .+
-                                    selectdim(payoff_array, 1, action:action),
-                                    (m, n)))
-    A[1:n, m+1] .= 1
-    A[n+1, 1:m] .= 1
-    A[n+1, m+1] = 0
+    A_ub = Matrix{T}(undef, (m+1, n))  # transposed
+    A_ub[1:end-1, :] .= reshape(selectdim(payoff_array, 1, action), (1, n))
+    A_ub[1:end-1, :] -= reshape(selectdim(payoff_array, 1, ind), (m, n))
+    A_ub[end, :] .= 1
 
-    b = zeros(S, n+1)
-    b[end] = 1
+    a_eq = ones(T, m+1)
+    a_eq[end] = 0
 
-    c = zeros(S, m+1)
-    c[end] = -1
+    c = zeros(T, m+1)
+    c[end] = 1
 
-    sense = Array{Char}(undef, n+1)
-    for i in 1:n
-      sense[i] = '<'
+    optimizer = lp_solver()
+    x = MOI.add_variables(optimizer, m+1)
+    MOI.set(optimizer, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.(c, x), 0))
+    MOI.set(optimizer, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    for j in 1:n
+        MOI.add_constraint(
+            optimizer,
+            MOI.ScalarAffineFunction{T}(
+                MOI.ScalarAffineTerm{T}.(A_ub[:, j], x), 0
+            ),
+            MOI.LessThan{T}(0)
+        )
     end
-    sense[n+1] = '='
+    MOI.add_constraint(
+        optimizer,
+        MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.(a_eq, x), 0),
+        MOI.EqualTo{T}(1)
+    )
+    # Nonnegativity
+    for i in 1:m
+        a = zeros(T, m+1)
+        a[i] = -1
+        MOI.add_constraint(
+            optimizer,
+            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.(a, x), 0),
+            MOI.LessThan{T}(0)
+        )
+    end
+    MOI.optimize!(optimizer)
+    status = MOI.get(optimizer, MOI.TerminationStatus())
 
-    res = linprog(c, A, sense, b, lp_solver)
-
-    if res.status == :Optimal
-        return (res.sol[end] > tol)::Bool
-    elseif res.status == :Infeasible
+    if status == MOI.OPTIMAL
+        return (MOI.get(optimizer, MOI.ObjectiveValue()) > tol)::Bool
+    elseif status == MOI.INFEASIBLE
         return false
     else
-        throw(ErrorException("Error: solution status $(res.status)"))
+        throw(ErrorException("Error: solution status $(status)"))
     end
 end
 
-function is_dominated(player::Player{1}, action::PureAction;
-                      tol::Real=1e-8,
-                      lp_solver::MathProgBase.AbstractMathProgSolver=
-                      ClpSolver())
+function is_dominated(::Type{T}, player::Player{1}, action::PureAction;
+                      tol::Real=1e-8, lp_solver::OptimizerFactory=
+                      with_optimizer(Clp.Optimizer, LogLevel=0)) where T<:Real
         payoff_array = player.payoff_array
         return maximum(payoff_array) > payoff_array[action] + tol
 end
 
+is_dominated(player::Player, action::PureAction; tol::Real=1e-8,
+             lp_solver::OptimizerFactory=
+             with_optimizer(Clp.Optimizer, LogLevel=0)) =
+    is_dominated(Float64, player, action, tol=tol, lp_solver=lp_solver)
+
 # dominated_actions
 
 """
-    dominated_actions(player; tol=1e-8, lp_solver=ClpSolver())
+    dominated_actions(player; tol=1e-8,
+                      lp_solver=JuMP.with_optimizer(Clp.Optimizer, LogLevel=0))
 
 Return a vector of actions that are strictly dominated by some mixed actions.
 
@@ -929,7 +952,9 @@ Return a vector of actions that are strictly dominated by some mixed actions.
 
 - `player::Player` : Player instance.
 - `tol::Real` : Tolerance level used in determining domination.
-- `lp_solver::AbstractMathProgSolver` : See `is_dominated`.
+- `lp_solver::JuMP.OptimizerFactory` : Linear programming solver to be used
+  internally. For default, `JuMP.with_optimizer(Clp.Optimizer, LogLevel=0)` is
+  passed.
 
 # Returns
 
@@ -937,15 +962,21 @@ Return a vector of actions that are strictly dominated by some mixed actions.
   of which is strictly dominated by some mixed action.
 
 """
-function dominated_actions(player::Player; tol::Real=1e-8,
-                           lp_solver::MathProgBase.AbstractMathProgSolver=
-                           ClpSolver())
-    out = Vector{Int}(undef, 0)
+function dominated_actions(
+    ::Type{T}, player::Player; tol::Real=1e-8,
+    lp_solver::OptimizerFactory=with_optimizer(Clp.Optimizer, LogLevel=0)
+) where T<:Real
+    out = Int[]
     for action = 1:num_actions(player)
-        if is_dominated(player, action, tol=tol, lp_solver=lp_solver)
+        if is_dominated(T, player, action, tol=tol, lp_solver=lp_solver)
             append!(out, action);
         end
     end
 
     return out
 end
+
+dominated_actions(player::Player; tol::Real=1e-8,
+                  lp_solver::OptimizerFactory=
+                  with_optimizer(Clp.Optimizer, LogLevel=0)) =
+    dominated_actions(Float64, player, tol=tol, lp_solver=lp_solver)

--- a/test/test_normal_form_game.jl
+++ b/test/test_normal_form_game.jl
@@ -6,7 +6,6 @@
 #       that multiple times for the same function if we have particular reason
 #       to believe there might be a type stability with that function.
 
-using JuMP
 using Clp
 using CDDLib
 
@@ -332,8 +331,7 @@ using CDDLib
 
     @testset "is_dominated linprog error" begin
         player = Player([1. 1.; 0. -1.; -1. 0.])
-        lp_solver =
-            with_optimizer(Clp.Optimizer, LogLevel=0, MaximumIterations=1)
+        lp_solver = () -> Clp.Optimizer(LogLevel=0, MaximumIterations=1)
         @test_throws ErrorException is_dominated(player, 1,
                                                  lp_solver=lp_solver)
     end
@@ -447,7 +445,7 @@ using CDDLib
 
         @testset "Test rational input game" begin
             T = Rational{BigInt}
-            lp_solver = with_optimizer(CDDLib.Optimizer{T})
+            lp_solver = CDDLib.Optimizer{T}
 
             # Corner cases
             e = 1//(2^25)
@@ -461,7 +459,7 @@ using CDDLib
 
             player.payoff_array[1, 1:2] .= 0;
 
-            @test !is_dominated(T, player, action, tol=01, lp_solver=lp_solver)
+            @test !is_dominated(T, player, action, tol=0, lp_solver=lp_solver)
 
             # Simple game
             game_matrix = [2//3 1//3;

--- a/test/test_normal_form_game.jl
+++ b/test/test_normal_form_game.jl
@@ -6,6 +6,7 @@
 #       that multiple times for the same function if we have particular reason
 #       to believe there might be a type stability with that function.
 
+using JuMP
 using Clp
 using CDDLib
 
@@ -331,7 +332,8 @@ using CDDLib
 
     @testset "is_dominated linprog error" begin
         player = Player([1. 1.; 0. -1.; -1. 0.])
-        lp_solver = ClpSolver(MaximumIterations=1)
+        lp_solver =
+            with_optimizer(Clp.Optimizer, LogLevel=0, MaximumIterations=1)
         @test_throws ErrorException is_dominated(player, 1,
                                                  lp_solver=lp_solver)
     end
@@ -444,7 +446,8 @@ using CDDLib
         end
 
         @testset "Test rational input game" begin
-            lp_solver = CDDSolver(exact=true)
+            T = Rational{BigInt}
+            lp_solver = with_optimizer(CDDLib.Optimizer{T})
 
             # Corner cases
             e = 1//(2^25)
@@ -453,19 +456,19 @@ using CDDLib
                              -1//1 1//1])
 
             action = 1
-            @test !is_dominated(player, action, tol=e, lp_solver=lp_solver)
-            @test is_dominated(player, action, tol=e//2, lp_solver=lp_solver)
+            @test !is_dominated(T, player, action, tol=e, lp_solver=lp_solver)
+            @test is_dominated(T, player, action, tol=e//2, lp_solver=lp_solver)
 
             player.payoff_array[1, 1:2] .= 0;
 
-            @test !is_dominated(player, action, tol=0//1, lp_solver=lp_solver)
+            @test !is_dominated(T, player, action, tol=01, lp_solver=lp_solver)
 
             # Simple game
             game_matrix = [2//3 1//3;
                            1//3 2//3]
             player = Player(game_matrix)
 
-            @test dominated_actions(player, lp_solver=lp_solver) == Int[]
+            @test dominated_actions(T, player, lp_solver=lp_solver) == Int[]
         end
     end
 


### PR DESCRIPTION
Close #108

Here is my proposal regarding LP solver. One disadvantage is the dependency on `JuMP` despite the only use of `JuMP.OptimizerFactory` and `JuMP.with_optimizer`.