### PR TITLE
Remove warn for Julia 1.2

### DIFF
--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -494,7 +494,7 @@ function outerapproximation(
         end
 
         if iter >= maxiter
-            warn("Maximum Iteration Reached")
+            @warn "Maximum Iteration Reached"
         end
 
         # Update hyperplane levels


### PR DESCRIPTION
`warn` cannot be used in Julia v0.7.0~ 
Use `@warn` instead of `warn`