### PR TITLE
Update to MOI v0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ jobs:
       julia: 1.0
       os: linux
       script:
-        - julia -e 'using Pkg; Pkg.add("Documenter"); using Documenter'
-        - julia -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
-        - julia -e 'using Games; cd(joinpath(dirname(pathof(Games)), "..")); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+        - julia --project=docs/ -e 'using Games; cd(joinpath(dirname(pathof(Games)), "..")); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'
       after_success: skip
 after_success:
   - julia -e 'using Pkg; using Games; cd(joinpath(dirname(pathof(Games)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,30 @@
+name = "Games"
+uuid = "d5cce6e7-4428-536b-a17f-94dfa0e3a07a"
+repo = "https://github.com/QuantEcon/Games.jl.git"
+
+[deps]
+Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+Polyhedra = "67491407-f73d-577b-9b50-8179a7c68029"
+QuantEcon = "fcd29c91-0bd7-5a09-975d-7ac3f643a60c"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[compat]
+QuantEcon = "≥ 0.16.0"
+julia = "≥ 1.0.0"
+
+[extras]
+CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[targets]
+test = ["Combinatorics", "CDDLib", "DelimitedFiles", "LinearAlgebra", "Test", "Random", "Unicode"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,0 @@
-julia 1.0
-QuantEcon 0.16
-Combinatorics
-Parameters
-MathOptInterface
-Clp
-Polyhedra
-LightGraphs

--- a/src/Games.jl
+++ b/src/Games.jl
@@ -11,6 +11,7 @@ using Parameters
 # Optimization packages
 using MathOptInterface
 const MOI = MathOptInterface
+const MOIU = MOI.Utilities
 using Clp
 
 # Geometry packages

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -887,7 +887,8 @@ function is_dominated(
     c = zeros(T, m+1)
     c[end] = 1
 
-    optimizer = lp_solver()
+    CACHE = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    optimizer = MOIU.CachingOptimizer(CACHE, lp_solver())
     x = MOI.add_variables(optimizer, m+1)
     MOI.set(optimizer, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
             MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.(c, x), 0))

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -272,7 +272,8 @@ function worst_value_i(
     c = zeros(2)
     c[i] = 1.0
 
-    optimizer = lp_solver()
+    CACHE = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    optimizer = MOIU.CachingOptimizer(CACHE, lp_solver())
 
     # Add variables
     x = MOI.add_variables(optimizer, 2)
@@ -367,6 +368,11 @@ function outerapproximation(
         plib::Polyhedra.Library=default_library(2, Float64),
         lp_solver::Union{Type{TO},Function}=() -> Clp.Optimizer(LogLevel=0)
     ) where {TO<:MOI.AbstractOptimizer}
+
+    # set up optimizer
+    CACHE = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    optimizer = MOIU.CachingOptimizer(CACHE, lp_solver())
+
     # Long unpacking of stuff
     sg, delta = unpack(rpd)
     p1, p2 = sg.players
@@ -429,7 +435,7 @@ function outerapproximation(
                 b[nH+2] = (1-delta)*flow_u_2(rpd, a1, a2) -
                           (1-delta)*best_dev_payoff_2(rpd, a1) - delta*_w2
 
-                optimizer = lp_solver()
+                MOI.empty!(optimizer)
 
                 # Add variables
                 x = MOI.add_variables(optimizer, 2)


### PR DESCRIPTION
closes #121 

1. create `CACHE` and attach it to `optimizer` each time `is_dominated` and `worst_value_i` are called,
2. in `outerapproximation`, a cached `optimizer` is set up at the beginning of the code and then is used repeatedly. In each iteration, `MOI.empty!(optimizer)` must be called.

This PR need to be merged after #120. I tried this in my forked repo and all tests passed.