### PR TITLE
Always show game payoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ using GameTheory
 player1 = Player([3 3; 2 5; 0 6])
 player2 = Player([3 2 3; 2 6 1])
 g = NormalFormGame(player1, player2)
-println(g)
 ```
 ```
 3×2 NormalFormGame{2, Int64}:
@@ -46,7 +45,7 @@ g[1, 1, 1] = [9, 8, 12]
 g[2, 2, 1] = [9, 8, 2]
 g[1, 2, 2] = [3, 4, 6]
 g[2, 1, 2] = [3, 4, 4]
-println(g)
+g
 ```
 ```
 2×2×2 NormalFormGame{3, Float64}:

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -680,7 +680,7 @@ Base.summary(g::NormalFormGame) =
            " ",
            split(string(typeof(g)), ".")[end])
 
-# payoff_profile_array
+
 
 """
     payoff_profile_array(g)
@@ -709,14 +709,25 @@ function payoff_profile_array(g::NormalFormGame{N,T}) where {N,T}
     return payoff_profile_array
 end
 
-function Base.show(io::IO, g::NormalFormGame)
-    print(io, summary(g))
+"""
+LazyProfileArray
+
+Construct a lazily-evaluated array of payoff profiles. Each profile is a Vector that is created when getindex is called.
+
+This is meant to aid in printing without allocating large arrays
+"""
+struct LazyProfileArray{N,T,G<:NormalFormGame{N,T}} <: AbstractArray{Vector{T},N}
+    g::G
 end
 
-function Base.print(io::IO, g::NormalFormGame)
+Base.size(a::LazyProfileArray) = a.g.nums_actions
+Base.getindex(a::LazyProfileArray, index::Int...) = a.g[index...]
+Base.getindex(a::LazyProfileArray{N}, ci::CartesianIndex{N}) where {N} = a.g[ci]
+
+function Base.show(io::IO, g::NormalFormGame)
     print(io, summary(g))
     println(io, ":")
-    X = payoff_profile_array(g)
+    X = LazyProfileArray(g)
     if !haskey(io, :compact) && length(axes(X, 2)) > 1
         io = IOContext(io, :compact => true)
     end

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -714,7 +714,7 @@ LazyProfileArray
 
 Construct a lazily-evaluated array of payoff profiles. Each profile is a Vector that is created when getindex is called.
 
-This is meant to aid in printing without allocating large arrays
+This is meant to aid in printing without allocating large arrays.
 """
 struct LazyProfileArray{N,T} <: AbstractArray{Vector{T},N}
     g::NormalFormGame{N,T}

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -716,19 +716,19 @@ Construct a lazily-evaluated array of payoff profiles. Each profile is a Vector 
 
 This is meant to aid in printing without allocating large arrays
 """
-struct LazyProfileArray{N,T,G<:NormalFormGame{N,T}} <: AbstractArray{Vector{T},N}
-    g::G
+struct LazyProfileArray{N,T} <: AbstractArray{Vector{T},N}
+    g::NormalFormGame{N,T}
 end
 
 Base.size(a::LazyProfileArray) = a.g.nums_actions
-Base.getindex(a::LazyProfileArray, index::Int...) = a.g[index...]
-Base.getindex(a::LazyProfileArray{N}, ci::CartesianIndex{N}) where {N} = a.g[ci]
+Base.getindex(a::LazyProfileArray{N}, index::Vararg{Int,N}) where {N} = a.g[index...]
+Base.getindex(a::LazyProfileArray{1}, index::Int) = [a.g[index]]
 
 function Base.show(io::IO, g::NormalFormGame)
     print(io, summary(g))
     println(io, ":")
     X = LazyProfileArray(g)
-    if !haskey(io, :compact) && length(axes(X, 2)) > 1
+    if !haskey(io, :compact) && ndims(X) >= 2 && length(axes(X, 2)) > 1
         io = IOContext(io, :compact => true)
     end
     Base.print_array(io, X)

--- a/test/test_normal_form_game.jl
+++ b/test/test_normal_form_game.jl
@@ -294,6 +294,10 @@ using CDDLib
         @test occursin(string(typeof(g)), repr(g))
         @test occursin(sprint(Base.print_array, a), sprint(print, g))
         @test sprint(print, g) == sprint(show, g)
+
+        # See pull request #217
+        g1 = NormalFormGame((3,))
+        @test sprint(show, g1) isa String
     end
 
     @testset "Tests on delete_action for NormalFormGame" begin

--- a/test/test_normal_form_game.jl
+++ b/test/test_normal_form_game.jl
@@ -295,7 +295,7 @@ using CDDLib
         @test occursin(sprint(Base.print_array, a), sprint(print, g))
         @test sprint(print, g) == sprint(show, g)
 
-        # See pull request #217
+        # See pull request #218
         g1 = NormalFormGame((3,))
         @test sprint(show, g1) isa String
     end

--- a/test/test_normal_form_game.jl
+++ b/test/test_normal_form_game.jl
@@ -293,6 +293,7 @@ using CDDLib
         g = NormalFormGame(a)
         @test occursin(string(typeof(g)), repr(g))
         @test occursin(sprint(Base.print_array, a), sprint(print, g))
+        @test sprint(print, g) == sprint(show, g)
     end
 
     @testset "Tests on delete_action for NormalFormGame" begin


### PR DESCRIPTION
As mentioned in #217 , printing the payoff matrix in the repl will help new users catch errors. Previously, this was not implemented because it required allocating the payoff matrix (which could allocate alot). Now it uses a lazy array so that there are no allocations and it only accesses elements that it prints.

Example: for `g = NormalFormGame(Player(rand([1,2,3],10000,10000)), Player(rand([1,2,3],10000,10000)))
`, the following runs instantly:

```
julia> g
10000×10000 NormalFormGame{2, Int64}:
 [1, 1]  [3, 2]  [1, 2]  [3, 3]  [3, 3]  …  [3, 1]  [1, 1]  [1, 1]  [1, 2]
 [3, 2]  [3, 1]  [1, 2]  [3, 1]  [1, 2]     [3, 1]  [1, 2]  [3, 2]  [1, 3]
 [2, 2]  [1, 2]  [1, 3]  [1, 3]  [2, 3]     [3, 3]  [2, 3]  [1, 2]  [2, 1]
 [2, 2]  [2, 2]  [3, 2]  [1, 2]  [1, 1]     [1, 2]  [1, 2]  [2, 2]  [3, 3]
 [2, 1]  [2, 3]  [2, 1]  [3, 2]  [2, 1]     [2, 3]  [3, 1]  [3, 2]  [2, 1]
 [2, 1]  [2, 3]  [1, 3]  [3, 3]  [3, 2]  …  [1, 2]  [1, 1]  [1, 3]  [2, 3]
 [2, 2]  [2, 3]  [1, 3]  [2, 1]  [1, 3]     [3, 2]  [1, 1]  [1, 3]  [3, 1]
 [2, 2]  [1, 2]  [3, 2]  [2, 1]  [2, 2]     [1, 3]  [3, 1]  [3, 3]  [1, 2]
 [2, 1]  [2, 3]  [3, 1]  [3, 2]  [1, 2]     [1, 3]  [3, 3]  [3, 3]  [3, 2]
 [3, 3]  [3, 3]  [1, 1]  [2, 3]  [1, 1]     [3, 1]  [3, 3]  [1, 1]  [1, 2]
 ⋮                                       ⋱                          
 [2, 3]  [3, 1]  [2, 3]  [2, 3]  [3, 2]     [3, 3]  [3, 1]  [1, 3]  [2, 1]
 [1, 3]  [2, 1]  [2, 3]  [1, 1]  [2, 3]     [1, 1]  [2, 2]  [2, 2]  [1, 3]
 [1, 1]  [1, 1]  [3, 1]  [3, 2]  [2, 3]     [3, 2]  [3, 2]  [2, 2]  [2, 3]
 [2, 1]  [2, 3]  [1, 2]  [2, 1]  [3, 3]     [1, 1]  [1, 1]  [1, 1]  [3, 2]
 [1, 3]  [2, 1]  [2, 1]  [2, 1]  [1, 2]  …  [3, 2]  [1, 1]  [2, 2]  [2, 2]
 [1, 2]  [3, 2]  [2, 3]  [3, 1]  [2, 3]     [3, 1]  [2, 1]  [3, 3]  [1, 2]
 [1, 2]  [1, 1]  [3, 1]  [2, 2]  [3, 1]     [2, 2]  [3, 2]  [3, 1]  [1, 3]
 [3, 2]  [1, 3]  [1, 1]  [1, 1]  [1, 3]     [2, 2]  [1, 2]  [2, 1]  [2, 2]
 [3, 1]  [1, 2]  [2, 2]  [1, 3]  [1, 1]     [2, 3]  [1, 1]  [2, 1]  [2, 3]
```