### PR TITLE
DOC: Fix invalid type-bound syntax in Player/NormalFormGame field docstrings

### DIFF
--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -20,8 +20,8 @@ Type representing a player in an N-player normal form game.
 
 # Fields
 
-- `payoff_array::Array{T<:Real}` : Array representing the player's payoff
-  function.
+- `payoff_array::Array{T,N}` : Array representing the player's payoff function,
+  where `T<:Real`.
 """
 struct Player{N,T<:Real}
     payoff_array::Array{T,N}
@@ -474,7 +474,7 @@ Type representing an N-player normal form game.
 
 # Fields
 
-- `players::NTuple{N,Player{N,T<:Real}}` : Tuple of Player instances.
+- `players::NTuple{N,Player{N,T}}` : Tuple of Player instances, where `T<:Real`.
 - `nums_actions::NTuple{N,Int}` : Tuple of the numbers of actions, one for each
   player.
 """


### PR DESCRIPTION
## Summary

- The `# Fields` bullets in the `Player{N,T}` and `NormalFormGame{N,T}` docstrings used `Array{T<:Real}` and `NTuple{N,Player{N,T<:Real}}`, which are not valid Julia type expressions (named-typevar bounds are only allowed in struct heads or `where` clauses).
- Rewrote both bullets to use the field's actual type (`Array{T,N}` / `NTuple{N,Player{N,T}}`) and moved the bound to a trailing `where T<:Real` in the description sentence, matching the docstring style introduced for the constructors in #221.

## Test plan
- [ ] `Documenter` build / `@doc Player` / `@doc NormalFormGame` show the corrected text
- [ ] No code paths changed; existing test suite should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)