### PR TITLE
Add compact `text/plain` display handling

### DIFF
--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -76,6 +76,7 @@ Base.summary(player::Player) =
            split(string(typeof(player)), ".")[end])
 
 function Base.show(io::IO, ::MIME"text/plain", player::Player)
+    get(io, :compact, false)::Bool && return show(io, player)
     print(io, summary(player))
     println(io, ":")
     X = player.payoff_array
@@ -777,6 +778,7 @@ function Base.show(io::IO, g::NormalFormGame)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", g::NormalFormGame)
+    get(io, :compact, false)::Bool && return show(io, g)
     print(io, summary(g))
     println(io, ":")
     X = LazyProfileArray(g)

--- a/test/test_normal_form_game.jl
+++ b/test/test_normal_form_game.jl
@@ -438,6 +438,34 @@ using CDDLib
         end
     end
 
+    @testset "Test compact text/plain display" begin
+        struct CompactTextPlainWrapper{T}
+            x::T
+        end
+
+        function Base.show(io::IO, ::MIME"text/plain", w::CompactTextPlainWrapper)
+            print(io, "CompactTextPlainWrapper(")
+            show(IOContext(io, :compact => true), MIME"text/plain"(), w.x)
+            print(io, ")")
+        end
+
+        p1 = Player([1 2; 3 4; 5 6])
+        p2 = Player([11 12 13; 14 15 16])
+        g = NormalFormGame(p1, p2)
+
+        @testset "show for Player" begin
+            p_out = sprint(show, MIME"text/plain"(), CompactTextPlainWrapper(p1))
+            @test !occursin('\n', p_out)
+            @test p_out == "CompactTextPlainWrapper($(sprint(show, p1)))"
+        end
+
+        @testset "show for NormalFormGame" begin
+            g_out = sprint(show, MIME"text/plain"(), CompactTextPlainWrapper(g))
+            @test !occursin('\n', g_out)
+            @test g_out == "CompactTextPlainWrapper($(sprint(show, g)))"
+        end
+    end
+
     @testset "Tests on delete_action for NormalFormGame" begin
         shapley_game = Array{Int}(undef, 3, 3, 2)
         shapley_game[:, 1, 1] = [0, 0, 1]


### PR DESCRIPTION
(Changes suggested by ChatGPT 5.5 Pro)

Update `show(io, MIME"text/plain", ...)` for `Player` and `NormalFormGame` to respect `:compact => true` by delegating to 2-arg `show`.

Follows the recommendation in the [documentation of `Base.show`](https://docs.julialang.org/en/v1/base/io-network/#Base.show-Tuple{IO,%20Any}):
> Checking the :compact [IOContext](https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext) key (often checked as get(io, :compact, false)::Bool) of io in such methods is recommended, since some containers show their elements by calling this method with :compact => true.