### PR TITLE
TST: Pass compile=false to hc_solve in tests

### DIFF
--- a/test/test_homotopy_continuation.jl
+++ b/test/test_homotopy_continuation.jl
@@ -7,7 +7,8 @@
                ([4//5, 1//5, 0//1], [2//3, 1//3]),
                ([0//1, 1//3, 2//3], [1//3, 2//3])]
 
-        NEs_computed = @inferred hc_solve(g, show_progress=false)
+        NEs_computed = @inferred hc_solve(g, show_progress=false,
+                                          compile=false)
         @test isapprox_vecs_act_profs(NEs_computed, NEs)
     end
 
@@ -29,12 +30,14 @@
             ([1//2, 1//2], [1//3, 2//3], [1//4, 3//4])
         ]
 
-        NEs_computed = @inferred hc_solve(g, show_progress=false)
+        NEs_computed = @inferred hc_solve(g, show_progress=false,
+                                          compile=false)
         @test isapprox_vecs_act_profs(NEs_computed, NEs)
 
         ntofind = 1
         NEs_computed =
-            @inferred hc_solve(g, ntofind=ntofind, show_progress=false)
+            @inferred hc_solve(g, ntofind=ntofind, show_progress=false,
+                               compile=false)
         @test length(NEs_computed) == ntofind
         for i in 1:ntofind
             @test is_nash(g, NEs_computed[i])
@@ -56,7 +59,8 @@
         r = (-3q + 2) / (q + 1)
         NEs = [([p, 1-p], [q, 1-q], [r, 1-r])]
 
-        NEs_computed = @inferred hc_solve(g, show_progress=false)
+        NEs_computed = @inferred hc_solve(g, show_progress=false,
+                                          compile=false)
         @test isapprox_vecs_act_profs(NEs_computed, NEs)
     end
 


### PR DESCRIPTION
This PR passes `compile=false` (forwarded to `HomotopyContinuation.solve`) in the
`hc_solve` calls in `test/test_homotopy_continuation.jl`, reducing the wall time
of the test file by about 3 seconds at zero cost.

## Background

With the default `compile = :mixed`, `HomotopyContinuation.solve` generates and
compiles a specialized Julia evaluator for each polynomial system, costing about
2–2.5 seconds of code generation per system. Compiled evaluators are cached by
expression structure, but each of the three test games has a distinct structure,
so each pays this cost once in the test process.

With `compile = false`, the interpreted evaluator is used instead. At the sizes
of the test games, it is as fast as the compiled one at runtime (e.g., solving
the 2x2x2 game from McKelvey and McLennan takes ~0.03 seconds warm either way),
so skipping the code generation is a pure saving.

## Measurements

Time to run `test/test_homotopy_continuation.jl` in a fresh process (after
package precompilation, two runs each):

| state | run 1 | run 2 |
|---|---|---|
| `main` | 25.3 s | 26.1 s |
| this PR | 23.1 s | 23.0 s |

The remaining ~23 seconds is dominated by the one-time JIT compilation of
HomotopyContinuation.jl's solver machinery (path tracker, polyhedral start
systems, endgame) on the first `solve` call in the process, which is
independent of the `compile` option. Removing that cost would require a
`PrecompileTools` workload and is left out of scope here.

## Notes

- The two `hc_solve` calls in the 1-player testset are left unchanged, as they
  throw `ArgumentError` before reaching the solver.
- No changes to `src/`; test results are unaffected (`compile` only selects the
  evaluator used during path tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
