### PR TITLE
FIX: Address issues in AS and its tests

### DIFF
--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -678,8 +678,10 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
     # comparison) in exact arithmetic; otherwise proportional to the payoff
     # scale, since `isapprox` with the default `atol=0` never holds at an IC
     # boundary located at 0
+    payoff_scale = maximum(abs, v_old)
     atol_IC = S <: AbstractFloat ?
-              sqrt(eps(S)) * max(one(S), maximum(abs, v_old)) : zero(S)
+              sqrt(eps(S)) * (iszero(payoff_scale) ? one(S) : payoff_scale) :
+              zero(S)
 
     for iter = 1:maxiter
 

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -738,9 +738,7 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
         # update u
         u_ = [minimum(v_new[:, 1]),
               minimum(v_new[:, 2])]
-        if any(u_ .> u)
-            u = u_
-        end
+        u = max.(u, u_)
     end
 
     # Return matrix with coefficient type S

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -669,6 +669,13 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
     A_IC = -Matrix{S}(I, 2, 2)
     payoffs = Vector{S}(undef, 2)
 
+    # Tolerance for detecting vertices on the IC boundaries: zero (exact
+    # comparison) in exact arithmetic; otherwise proportional to the payoff
+    # scale, since `isapprox` with the default `atol=0` never holds at an IC
+    # boundary located at 0
+    atol_IC = S <: AbstractFloat ?
+              sqrt(eps(S)) * max(one(S), maximum(abs, v_old)) : zero(S)
+
     for iter = 1:maxiter
 
         v_new = S[] # to store new vertices
@@ -697,7 +704,8 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
                 p_inter = intersect(p_IC, p)
                 Vmat = MixedMatVRep(vrep(p_inter)).V
                 for i in 1:size(Vmat, 1)
-                    if Vmat[i, 1] ≈ IC1 || Vmat[i, 2] ≈ IC2
+                    if isapprox(Vmat[i, 1], IC1, atol=atol_IC) ||
+                       isapprox(Vmat[i, 2], IC2, atol=atol_IC)
                         push!(v_new, (rpd.delta * Vmat[i, :] +
                                       (one(S) - rpd.delta) * S[payoff1, payoff2])...)
                     end

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -626,11 +626,16 @@ julia> size(vertices_rat)
 ```
 
 There is a utility `uniquetolrows` which can be used to remove approximately
-duplicate rows:
+duplicate rows (the retained rows keep the exact values):
 
 ```julia
-julia> uniquetolrows(vertices_rat, 1e-8)
-4×2 Matrix{BigFloat}:
+julia> V = uniquetolrows(vertices_rat, 1e-8);
+
+julia> typeof(V)
+Matrix{Rational{BigInt}} (alias for Array{Rational{BigInt}, 2})
+
+julia> Float64.(V)
+4×2 Matrix{Float64}:
  9.0   9.0
  9.75  3.0
  3.0   9.75
@@ -763,21 +768,28 @@ end
 """
     uniquetolrows(V, tol)
 
-Remove near-duplicate rows from matrix V using tolerance-based deduplication.
+Remove near-duplicate rows from matrix `V`: scanning from the top, a row is
+dropped if it is within `tol`, in the Chebyshev distance, of a row retained
+earlier. The retained rows are returned unmodified, with the element type of
+`V` preserved.
 
 # Arguments
 
 - `V::AbstractMatrix{T}` : Input matrix where T<:Real.
-- `tol::Real` : Tolerance for considering points as duplicates.
+- `tol::Real` : Tolerance for considering rows as duplicates.
 
 # Returns
 
-- `::Matrix` : Matrix of floats with duplicate rows removed within tolerance.
+- `::Matrix{T}` : Matrix consisting of the retained rows of `V`.
 """
 function uniquetolrows(V::AbstractMatrix{T}, tol::Real) where T
-    digits = max(0, floor(Int, -log10(tol)))
-    Vr = round.(V; digits=digits)
-    return unique(Vr; dims=1)
+    keep = Int[]
+    for i in 1:size(V, 1)
+        if !any(j -> maximum(abs, V[i, :] - V[j, :]) < tol, keep)
+            push!(keep, i)
+        end
+    end
+    return V[keep, :]
 end
 
 """

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -787,7 +787,7 @@ earlier. The retained rows are returned unmodified, with the element type of
 function uniquetolrows(V::AbstractMatrix{T}, tol::Real) where T
     keep = Int[]
     for i in 1:size(V, 1)
-        if !any(j -> maximum(abs, V[i, :] - V[j, :]) < tol, keep)
+        if !any(j -> maximum(abs, V[i, :] - V[j, :]) <= tol, keep)
             push!(keep, i)
         end
     end

--- a/test/test_repeated_game.jl
+++ b/test/test_repeated_game.jl
@@ -61,26 +61,15 @@
     # Test AS algorithm
     #
     @testset "Testing AS algorithm" begin
-        # Helper function to test if each row of vertices approximately matches some row in expected
+        # Helper function to test if the rows of `vertices` and the rows of
+        # `expected` coincide as sets of points, within tolerance: every row
+        # of each matrix must be within `tol` of some row of the other
         function vertices_match_expected(vertices, expected; tol=1e-4)
-            # Convert to Float64 for comparison if needed
-            vertices_float = eltype(vertices) <: AbstractFloat ? vertices : Float64.(vertices)
-            expected_float = eltype(expected) <: AbstractFloat ? expected : Float64.(expected)
-            
-            # Check that each row in vertices is approximately equal to some row in expected
-            for i in 1:size(vertices_float, 1)
-                found_match = false
-                for j in 1:size(expected_float, 1)
-                    if maximum(abs, vertices_float[i, :] - expected_float[j, :]) < tol
-                        found_match = true
-                        break
-                    end
-                end
-                if !found_match
-                    return false
-                end
-            end
-            return true
+            rows(A) = [Float64.(A[i, :]) for i in 1:size(A, 1)]
+            iscovered(a, B) = any(maximum(abs, a - b) < tol for b in B)
+            vertices_rows, expected_rows = rows(vertices), rows(expected)
+            return all(iscovered(v, expected_rows) for v in vertices_rows) &&
+                   all(iscovered(e, vertices_rows) for e in expected_rows)
         end
         
         vertices = @inferred(AS(rpd; tol=1e-9))


### PR DESCRIPTION
This PR addresses several issues in the `AS` implementation and its tests,
found in a review of the code introduced in #65 and #191. Four independent
changes, one commit each:

## 1. TST: Make `vertices_match_expected` check both directions

The test helper introduced in #191 only checked that every computed vertex
matches some expected vertex, so a strict subset of the expected vertices —
or even an empty matrix — would pass all the `AS` testsets. The helper now
also requires that every expected vertex is matched by some computed vertex,
i.e., the two vertex sets must coincide as sets of points within tolerance.
This still accommodates the near-duplicate vertices that the exact
arithmetic path may return (e.g., the `(6, 2)` result in the `AS`
docstring example), without pinning the vertex count.

## 2. FIX: Update threat point componentwise in `AS`

The threat point update replaced the whole vector `u` whenever *any*
component of the new minima exceeded the corresponding component of `u`,
which could lower the other component if the new minima are not
componentwise weakly greater — possible under floating point roundoff, even
though exact arithmetic guarantees monotonicity. Now takes the
componentwise maximum.

## 3. FIX: Detect IC boundary vertices with explicit `atol` in `AS`

Vertices of the intersection polyhedron lying on the IC boundaries were
detected with `isapprox` at its defaults (`atol=0`, relative tolerance
only). A relative tolerance never holds at an IC boundary located at 0
unless the computed coordinate is exactly zero, so any rounding in the
intersection computation would silently drop such boundary vertices in the
`Float64` path. The check now uses an absolute tolerance proportional to
the payoff scale; in exact arithmetic the tolerance is zero, preserving the
exact comparison.

Note: this guards a latent failure mode. I could not trigger it on games
with clean payoffs (CDDLib returns exact zeros there, and the `Float64`
results agree with the exact arithmetic ground truth before and after the
change).

## 4. ENH: Preserve rows and eltype in `uniquetolrows`

`uniquetolrows` deduplicated by rounding all entries to about
`-log10(tol)` digits, which (i) returned rounded values instead of the
input rows, (ii) changed the element type (e.g., `Rational{BigInt}` →
`BigFloat`), and (iii) failed to merge rows within `tol` that straddle a
rounding boundary (e.g., rows at `0.00049999` and `0.00050001` with
`tol=1e-3`). It now deduplicates by greedy clustering: scanning from the
top, a row is dropped iff it is within `tol`, in Chebyshev distance, of a
row retained earlier; the retained rows keep their exact values and element
type.

**Behavior change** for callers relying on the rounded/float output of
`uniquetolrows`. The `AS` docstring example is updated accordingly.

## Verification

- The full repeated-game testset passes after each commit.
- The strengthened helper rejects subset/empty results while accepting the
  exact-arithmetic output with near-duplicate vertices.
- For change 3, `Float64` results on a game with minimax payoff exactly 0
  agree with the exact arithmetic (`Int` payoffs, `3//4` delta) ground truth.

Not included here: replacing the per-action-pair polyhedron intersections
with direct 2D polygon clipping (as in Abreu and Sannikov's own pivot
procedure), which would remove the fragility behind change 3 structurally
and speed up `AS` considerably. That is a larger rewrite, left for a
separate PR; the strengthened tests from this PR are a prerequisite for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
