### PR TITLE
ENH: Compute AS by direct 2D polygon clipping

### DIFF
--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -699,6 +699,79 @@ function _in_polygon(q::NTuple{2,S}, poly::Vector{NTuple{2,S}}, atol) where S
     return true
 end
 
+#
+# AS algorithm
+#
+# The structure follows the implementation in QuantEcon.py
+# (quantecon/game_theory/repeated_game.py): `AS` is the driver
+# (`_equilibrium_payoffs_abreu_sannikov` there), calling `_R` for each
+# application of the R operator, which in turn calls `_find_C` for the
+# IC-boundary points of each action profile.
+#
+
+"""
+    _find_C(poly, IC1, IC2, atol)
+
+Find the vertices of the convex polygon `poly` clipped to the IC region
+`{w : w[1] >= IC1, w[2] >= IC2}` that lie on an IC boundary, including, when
+it is in the polygon, the corner point `(IC1, IC2)`.
+
+Corresponds to `_find_C` in QuantEcon.py, which walks the hull edges; here
+the same points are obtained by clipping, which also handles degenerate
+(segment- or point-shaped) polygons.
+"""
+function _find_C(poly::Vector{NTuple{2,S}}, IC1, IC2, atol) where S
+    C = NTuple{2,S}[]
+    for w in _clip(_clip(poly, 1, IC1), 2, IC2)
+        if w[1] <= IC1 + atol || w[2] <= IC2 + atol
+            push!(C, w)
+        end
+    end
+    return C
+end
+
+"""
+    _R(rpd, best_dev_gains1, best_dev_gains2, poly, u, atol_in)
+
+Apply the R operator of Abreu and Sannikov (2014) once: collect, over all
+action profiles `a`, the candidate extreme points of the updated payoff set,
+namely the stage payoff `g(a)` itself if it is incentive compatible and in
+`poly`, and `(1-delta)g(a) + delta*w` for the points `w` of `poly` clipped
+to the IC region that lie on an IC boundary.
+
+Corresponds to `_R` in QuantEcon.py, with one difference: the IC-boundary
+points are collected also when `g(a)` itself is feasible (they are redundant
+in that case, and removed with the convex hull computation).
+"""
+function _R(rpd::RepGame2, best_dev_gains1, best_dev_gains2,
+            poly::Vector{NTuple{2,S}}, u, atol_in) where S
+    delta = rpd.delta
+    v_new = NTuple{2,S}[]
+    sizehint!(v_new, 8 * prod(rpd.sg.nums_actions))
+    for a2 in 1:rpd.sg.nums_actions[2]
+        for a1 in 1:rpd.sg.nums_actions[1]
+            payoff1 = rpd.sg.players[1].payoff_array[a1, a2]
+            payoff2 = rpd.sg.players[2].payoff_array[a2, a1]
+            IC1 = u[1] + best_dev_gains1[a1, a2]
+            IC2 = u[2] + best_dev_gains2[a2, a1]
+
+            # check if the payoff point is interior:
+            # first check if it satisfies IC,
+            # then check if it is in the polygon
+            if payoff1 > IC1 && payoff2 > IC2 &&
+                    _in_polygon((S(payoff1), S(payoff2)), poly, atol_in)
+                push!(v_new, (payoff1, payoff2))
+            end
+
+            for w in _find_C(poly, IC1, IC2, atol_in)
+                push!(v_new, ((one(S)-delta)*payoff1 + delta*w[1],
+                              (one(S)-delta)*payoff2 + delta*w[2]))
+            end
+        end
+    end
+    return v_new
+end
+
 """
     AS(rpd; maxiter=1000, tol=1e-5, u=nothing, verbose=false)
 
@@ -842,36 +915,8 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
 
     for iter = 1:maxiter
 
-        v_new = NTuple{2,S}[] # to store new vertices
-        sizehint!(v_new, 8 * prod(rpd.sg.nums_actions))
         # step 1
-        for a2 in 1:rpd.sg.nums_actions[2]
-            for a1 in 1:rpd.sg.nums_actions[1]
-                payoff1 = rpd.sg.players[1].payoff_array[a1, a2]
-                payoff2 = rpd.sg.players[2].payoff_array[a2, a1]
-                IC1 = u[1] + best_dev_gains1[a1, a2]
-                IC2 = u[2] + best_dev_gains2[a2, a1]
-
-                # check if the payoff point is interior:
-                # first check if it satisfies IC,
-                # then check if it is in the polygon
-                if payoff1 > IC1 && payoff2 > IC2 &&
-                        _in_polygon((S(payoff1), S(payoff2)), poly, atol_in)
-                    push!(v_new, (payoff1, payoff2))
-                end
-
-                # find the vertices of the polygon clipped to the IC region
-                # {w : w[1] >= IC1, w[2] >= IC2} that lie on an IC boundary
-                clipped = _clip(_clip(poly, 1, IC1), 2, IC2)
-                for w in clipped
-                    if w[1] <= IC1 + atol_in || w[2] <= IC2 + atol_in
-                        push!(v_new,
-                              ((one(S)-delta)*payoff1 + delta*w[1],
-                               (one(S)-delta)*payoff2 + delta*w[2]))
-                    end
-                end
-            end
-        end
+        v_new = _R(rpd, best_dev_gains1, best_dev_gains2, poly, u, atol_in)
 
         isempty(v_new) &&
             error("no incentive-compatible payoff vectors found: the game " *

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -758,7 +758,7 @@ in that case, and removed with the convex hull computation).
 """
 function _R(rpd::RepGame2, best_dev_gains1, best_dev_gains2,
             poly::Vector{NTuple{2,S}}, u, atol_in) where S
-    delta = rpd.delta
+    delta = convert(S, rpd.delta)
     v_new = NTuple{2,S}[]
     sizehint!(v_new, 8 * prod(rpd.sg.nums_actions))
     for a2 in 1:rpd.sg.nums_actions[2]

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -904,18 +904,18 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
     # payoff set rather than with its distance from the origin, making the
     # computation robust to translations of the payoffs. The centers are
     # added back to the output at the end. In exact arithmetic the centering
-    # has no effect on the result; near the origin it is skipped, as it is
-    # not needed there and would perturb the rounding of the common case.
+    # would have no effect on the result and is skipped; near the origin it
+    # is skipped as well, as it is not needed there and would perturb the
+    # rounding of the common case.
     extr1 = extrema(rpd.sg.players[1].payoff_array)
     extr2 = extrema(rpd.sg.players[2].payoff_array)
-    magnitude = max(abs(convert(S, extr1[1])), abs(convert(S, extr1[2])),
-                    abs(convert(S, extr2[1])), abs(convert(S, extr2[2])))
-    spread = max(convert(S, extr1[2]) - convert(S, extr1[1]),
-                 convert(S, extr2[2]) - convert(S, extr2[1]))
-    center = magnitude > 4 * spread ?
-             [(convert(S, extr1[1]) + convert(S, extr1[2])) / 2,
-              (convert(S, extr2[1]) + convert(S, extr2[2])) / 2] :
-             [zero(S), zero(S)]
+    lo1, hi1 = convert(S, extr1[1]), convert(S, extr1[2])
+    lo2, hi2 = convert(S, extr2[1]), convert(S, extr2[2])
+    magnitude = max(abs(lo1), abs(hi1), abs(lo2), abs(hi2))
+    spread = max(hi1 - lo1, hi2 - lo2)
+    do_center = S <: AbstractFloat && magnitude > 4 * spread
+    center = do_center ? [lo1 / 2 + hi1 / 2, lo2 / 2 + hi2 / 2] :
+                         [zero(S), zero(S)]
     payoff_array1 = S.(rpd.sg.players[1].payoff_array) .- center[1]
     payoff_array2 = S.(rpd.sg.players[2].payoff_array) .- center[2]
 

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -546,28 +546,184 @@ function outerapproximation(
     return vertices
 end
 
+#
+# 2D geometry primitives for the AS algorithm
+#
+# Convex polygons are represented as vectors of 2-tuples of coordinates, with
+# the vertices in counterclockwise order. All primitives use only +, -, *, /
+# and comparisons, so they are exact for Rational element types.
+#
+
+# 2D cross product of the vectors (b - a) and (c - a)
+_cross(a, b, c) = (b[1]-a[1])*(c[2]-a[2]) - (b[2]-a[2])*(c[1]-a[1])
+
+# Distance from the point `q` to the segment from `a` to `b`
+function _segment_dist(q, a, b)
+    d1, d2 = float(b[1]-a[1]), float(b[2]-a[2])
+    L2 = d1^2 + d2^2
+    t = iszero(L2) ? zero(L2) :
+        clamp((float(q[1]-a[1])*d1 + float(q[2]-a[2])*d2) / L2,
+              zero(L2), one(L2))
+    return hypot(float(q[1]-a[1]) - t*d1, float(q[2]-a[2]) - t*d2)
+end
+
 """
-    AS(rpd; maxiter=1000, plib=default_library(2, Float64), tol=1e-5,
-       u=nothing, verbose=false)
+    _convex_hull(pts)
+
+Convex hull of 2D points by Andrew's monotone chain algorithm. Return the
+vertices in counterclockwise order starting from the lexicographically
+smallest one; duplicate and interior (including collinear) points are
+dropped.
+"""
+function _convex_hull(pts::AbstractVector{NTuple{2,S}}) where S
+    pts = sort!(unique(pts))
+    length(pts) <= 2 && return pts
+    lower = NTuple{2,S}[]
+    for pt in pts
+        while length(lower) >= 2 && _cross(lower[end-1], lower[end], pt) <= 0
+            pop!(lower)
+        end
+        push!(lower, pt)
+    end
+    upper = NTuple{2,S}[]
+    for pt in Iterators.reverse(pts)
+        while length(upper) >= 2 && _cross(upper[end-1], upper[end], pt) <= 0
+            pop!(upper)
+        end
+        push!(upper, pt)
+    end
+    return vcat(lower[1:end-1], upper[1:end-1])
+end
+
+"""
+    _simplify(poly, atol)
+
+Simplify a convex polygon by merging consecutive vertices within `atol` in
+Chebyshev distance and dropping vertices within distance `atol` of the
+segment joining their neighbors. The distance to the segment, not to the
+line through it, is used: on degenerate, segment-like polygons the latter
+would erode true extreme points. No-op when `atol` is zero (exact
+arithmetic).
+"""
+function _simplify(poly::Vector{NTuple{2,S}}, atol) where S
+    (iszero(atol) || length(poly) <= 2) && return poly
+    kept = NTuple{2,S}[]
+    for w in poly
+        if isempty(kept) ||
+                max(abs(w[1]-kept[end][1]), abs(w[2]-kept[end][2])) > atol
+            push!(kept, w)
+        end
+    end
+    while length(kept) > 1 &&
+            max(abs(kept[end][1]-kept[1][1]),
+                abs(kept[end][2]-kept[1][2])) <= atol
+        pop!(kept)
+    end
+    changed = true
+    while changed && length(kept) > 2
+        changed = false
+        k = 1
+        while k <= length(kept) && length(kept) > 2
+            n = length(kept)
+            a, b, c = kept[mod1(k-1, n)], kept[k], kept[mod1(k+1, n)]
+            if _segment_dist(b, a, c) <= atol
+                deleteat!(kept, k)
+                changed = true
+            else
+                k += 1
+            end
+        end
+    end
+    return kept
+end
+
+"""
+    _clip(poly, i, c)
+
+Clip the convex polygon `poly` to the half-plane `{w : w[i] >= c}`.
+Intersection points with the boundary line get their `i`-th coordinate set
+to exactly `c`.
+"""
+function _clip(poly::Vector{NTuple{2,S}}, i::Integer, c) where S
+    n = length(poly)
+    if n == 1
+        return poly[1][i] >= c ? poly : NTuple{2,S}[]
+    end
+    out = NTuple{2,S}[]
+    for k in 1:n
+        a, b = poly[k], poly[mod1(k+1, n)]
+        a[i] >= c && push!(out, a)
+        if (a[i] >= c) != (b[i] >= c)
+            t = (c - a[i]) / (b[i] - a[i])
+            w = i == 1 ? (S(c), a[2] + t*(b[2]-a[2])) :
+                         (a[1] + t*(b[1]-a[1]), S(c))
+            push!(out, w)
+        end
+    end
+    return out
+end
+
+"""
+    _in_polygon(q, poly, atol)
+
+Whether the point `q` is in the convex polygon `poly`, allowing a slack of
+`atol` outside each edge.
+"""
+function _in_polygon(q::NTuple{2,S}, poly::Vector{NTuple{2,S}}, atol) where S
+    n = length(poly)
+    n == 0 && return false
+    if n == 1
+        return abs(q[1]-poly[1][1]) <= atol && abs(q[2]-poly[1][2]) <= atol
+    end
+    if n == 2  # degenerate polygon: a segment
+        a, b = poly
+        if iszero(atol)  # exact: on the line and within the bounding box
+            _cross(a, b, q) == 0 || return false
+            for j in 1:2
+                min(a[j], b[j]) <= q[j] <= max(a[j], b[j]) || return false
+            end
+            return true
+        end
+        return _segment_dist(q, a, b) <= atol
+    end
+    for k in 1:n
+        a, b = poly[k], poly[mod1(k+1, n)]
+        cr = _cross(a, b, q)
+        if iszero(atol)
+            cr >= 0 || return false
+        else
+            len = hypot(float(b[1]-a[1]), float(b[2]-a[2]))
+            cr >= -atol*len || return false
+        end
+    end
+    return true
+end
+
+"""
+    AS(rpd; maxiter=1000, tol=1e-5, u=nothing, verbose=false)
 
 Using AS algorithm to compute the set of payoff pairs of all pure-strategy
 subgame-perfect equilibria with public randomization for any repeated
 two-player games with perfect monitoring and discounting, following
 Abreu and Sannikov (2014).
 
-If the payoffs are Integer or Rational and the discount factor is Rational
-(and the library specified by `plib` supports exact arithmetic), this function
-performs exact arithmetic and returns a `Matrix{Rational{BigInt}}`.  Otherwise,
-it defaults to `Float64` computation.
+The geometry computations are performed by direct 2D polygon clipping, with
+no dependence on a polyhedra library.
+
+If the payoffs are Integer or Rational and the discount factor is Rational,
+this function performs exact arithmetic and returns a
+`Matrix{Rational{BigInt}}`. Otherwise, it defaults to `Float64` computation.
+Note that in exact arithmetic the size of the rational coefficients can grow
+very rapidly with the number of iterations, so that full convergence is
+feasible only when the vertices stabilize to simple rational values after a
+moderate number of iterations, as in the example below; otherwise, bound the
+computation with `maxiter`.
 
 # Arguments
 
 - `rpd::RepeatedGame{2, T, TD}` : Two player repeated game with T<:Real, TD<:Real.
 - `maxiter::Integer` : Maximum number of iterations.
-- `plib`: Allows users to choose a particular package for the geometry
-  computations.
-  (See [Polyhedra.jl](https://github.com/JuliaPolyhedra/Polyhedra.jl)
-  docs for more info). By default, it chooses to use `default_library`.
+- `plib` : Deprecated and unused; kept for backward compatibility.
 - `tol::Float64` : Tolerance in differences of set.
 - `u` : The punishment payoff pair if any player deviates. In default,
   we use minimax payoff pair. If there is better guess, you can specify it
@@ -598,9 +754,9 @@ julia> rpd = RepeatedGame(g, 0.75);
 julia> vertices = AS(rpd; tol=1e-9)
 4×2 Matrix{Float64}:
  3.0   3.0
- 3.0   9.75
- 9.0   9.0
  9.75  3.0
+ 9.0   9.0
+ 3.0   9.75
 ```
 
 If payoffs are Integer or Rational and the discount factor is Rational,
@@ -614,9 +770,7 @@ julia> g_int = NormalFormGame(Int, g)  # convert to Int-valued game
 
 julia> rpd_rat = RepeatedGame(g_int, 3//4);  # discount factor as Rational
 
-julia> using CDDLib
-
-julia> vertices_rat = AS(rpd_rat; tol=1e-9, plib=CDDLib.Library());
+julia> vertices_rat = AS(rpd_rat; tol=1e-9);
 
 julia> typeof(vertices_rat)
 Matrix{Rational{BigInt}} (alias for Array{Rational{BigInt}, 2})
@@ -636,18 +790,22 @@ Matrix{Rational{BigInt}} (alias for Array{Rational{BigInt}, 2})
 
 julia> Float64.(V)
 4×2 Matrix{Float64}:
- 9.0   9.0
- 9.75  3.0
- 3.0   9.75
  3.0   3.0
+ 9.75  3.0
+ 9.0   9.0
+ 3.0   9.75
 ```
 """
 function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
-            plib=default_library(2, Float64), tol::Float64=1e-5,
+            plib=nothing, tol::Float64=1e-5,
             u::Union{AbstractVector, Nothing}=nothing, verbose::Bool=false) where {T,TD}
 
+    plib === nothing || Base.depwarn(
+        "the `plib` keyword argument is deprecated and unused: " *
+        "`AS` no longer relies on a polyhedra library", :AS)
+
     S = _coefficient_type(rpd)
-    lib = similar_library(plib, 2, S)
+    delta = rpd.delta
 
     # Initialize W0 with each entries of payoff bimatrix
     v_old = _payoff_points(S, rpd.sg)
@@ -661,32 +819,30 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
         u = convert(Vector{S}, max.(u, mins))
     end
 
-    # create VRepresentation and Polyhedron and get rid of redundant vertices
-    p = polyhedron(vrep(v_old), lib)
-    removevredundancy!(p)
-    H = hrep(p)
-
     # calculate the best deviation gains
     # normalize with (1-delta)/delta
-    best_dev_gains1, best_dev_gains2 = (one(S)-rpd.delta)/rpd.delta .* _best_dev_gains(rpd.sg)
+    best_dev_gains1, best_dev_gains2 =
+        (one(S)-delta)/delta .* _best_dev_gains(rpd.sg)
 
-    # Precompute A_IC matrix and preallocate payoffs vector for performance
-    A_IC = -Matrix{S}(I, 2, 2)
-    payoffs = Vector{S}(undef, 2)
-
-    # Tolerance for detecting vertices on the IC boundaries: zero (exact
-    # comparison) in exact arithmetic; otherwise proportional to the payoff
-    # scale, since `isapprox` with the default `atol=0` never holds at an IC
-    # boundary located at 0
+    # Geometric tolerances, both zero (exact comparisons) in exact
+    # arithmetic. `atol_merge` merges near-duplicate and near-collinear hull
+    # vertices; `atol_in` is the slack for the membership and IC-boundary
+    # tests and is coarser: for those predicates false negatives lose genuine
+    # vertices of the equilibrium payoff set, while false positives only add
+    # redundant points of B(W), so err on the loose side.
     payoff_scale = maximum(abs, v_old)
-    atol_IC = S <: AbstractFloat ?
-              sqrt(eps(S)) * (iszero(payoff_scale) ? one(S) : payoff_scale) :
-              zero(S)
+    scale = iszero(payoff_scale) ? one(S) : payoff_scale
+    atol_merge = S <: AbstractFloat ? sqrt(eps(S)) * scale : zero(S)
+    atol_in = S <: AbstractFloat ? cbrt(eps(S)) * scale : zero(S)
+
+    # W as a convex polygon with vertices in counterclockwise order,
+    # without redundant points
+    poly = _simplify(_convex_hull(
+        [(v_old[i, 1], v_old[i, 2]) for i in 1:size(v_old, 1)]), atol_merge)
 
     for iter = 1:maxiter
 
-        v_new = S[] # to store new vertices
-        # Use sizehint! for better performance as suggested in PR #65
+        v_new = NTuple{2,S}[] # to store new vertices
         sizehint!(v_new, 8 * prod(rpd.sg.nums_actions))
         # step 1
         for a2 in 1:rpd.sg.nums_actions[2]
@@ -696,39 +852,40 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
                 IC1 = u[1] + best_dev_gains1[a1, a2]
                 IC2 = u[2] + best_dev_gains2[a2, a1]
 
-                # check if the payoff point is interior
-                # first check if it satisifies IC
-                if payoff1 > IC1 && payoff2 > IC2
-                    # then check if it is in the polyhedron
-                    payoffs[1] = payoff1; payoffs[2] = payoff2
-                    if payoffs in H
-                        push!(v_new, payoff1, payoff2)
-                    end
+                # check if the payoff point is interior:
+                # first check if it satisfies IC,
+                # then check if it is in the polygon
+                if payoff1 > IC1 && payoff2 > IC2 &&
+                        _in_polygon((S(payoff1), S(payoff2)), poly, atol_in)
+                    push!(v_new, (payoff1, payoff2))
                 end
 
-                # find out the intersections of polyhedron and IC boundaries
-                p_IC = polyhedron(hrep(A_IC, -S[IC1, IC2]), lib)
-                p_inter = intersect(p_IC, p)
-                Vmat = MixedMatVRep(vrep(p_inter)).V
-                for i in 1:size(Vmat, 1)
-                    if isapprox(Vmat[i, 1], IC1, atol=atol_IC) ||
-                       isapprox(Vmat[i, 2], IC2, atol=atol_IC)
-                        push!(v_new, (rpd.delta * Vmat[i, :] +
-                                      (one(S) - rpd.delta) * S[payoff1, payoff2])...)
+                # find the vertices of the polygon clipped to the IC region
+                # {w : w[1] >= IC1, w[2] >= IC2} that lie on an IC boundary
+                clipped = _clip(_clip(poly, 1, IC1), 2, IC2)
+                for w in clipped
+                    if w[1] <= IC1 + atol_in || w[2] <= IC2 + atol_in
+                        push!(v_new,
+                              ((one(S)-delta)*payoff1 + delta*w[1],
+                               (one(S)-delta)*payoff2 + delta*w[2]))
                     end
                 end
             end
         end
 
-        v_new = reshape(v_new, 2, :)'
+        isempty(v_new) &&
+            error("no incentive-compatible payoff vectors found: the game " *
+                  "may have no pure-action subgame perfect equilibrium " *
+                  "for this value of delta")
 
         # get rid of redundant points
-        p = polyhedron(vrep(v_new), lib)
-        removevredundancy!(p)
+        poly = _simplify(_convex_hull(v_new), atol_merge)
 
-        # check if it's converged
-        # Use deduplicated vertices for convergence check
-        v_dedup = MixedMatVRep(vrep(p)).V
+        # check if it's converged, using the deduplicated vertices
+        v_dedup = Matrix{S}(undef, length(poly), 2)
+        for (i, w) in enumerate(poly)
+            v_dedup[i, 1], v_dedup[i, 2] = w
+        end
         # first check if the numbers of vertices are the same
         if size(v_dedup) == size(v_old)
             # Sort rows before comparison since vertex order is not guaranteed
@@ -747,21 +904,18 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
         end
 
         v_old = v_dedup
-        H = hrep(p)
 
         # step 2
         # update u
-        u_ = [minimum(v_new[:, 1]),
-              minimum(v_new[:, 2])]
+        u_ = [minimum(w[1] for w in v_new),
+              minimum(w[2] for w in v_new)]
         u = max.(u, u_)
     end
 
     # Return matrix with coefficient type S
-    vr = vrep(p)
-    pts = points(vr)
-    vertices = Matrix{S}(undef, (npoints(vr), 2))
-    for (i, pt) in enumerate(pts)
-        vertices[i, :] = S.(pt)
+    vertices = Matrix{S}(undef, length(poly), 2)
+    for (i, w) in enumerate(poly)
+        vertices[i, 1], vertices[i, 2] = w
     end
 
     return vertices

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -637,6 +637,14 @@ function _simplify(poly::Vector{NTuple{2,S}}, atol) where S
     return kept
 end
 
+# Intersection point of the segment from `a` to `b` with the line
+# {w : w[i] == c}, with the i-th coordinate set to exactly `c`
+function _intersection_point(a::NTuple{2,S}, b::NTuple{2,S}, i, c) where S
+    t = (c - a[i]) / (b[i] - a[i])
+    return i == 1 ? (S(c), a[2] + t*(b[2]-a[2])) :
+                    (a[1] + t*(b[1]-a[1]), S(c))
+end
+
 """
     _clip(poly, i, c)
 
@@ -649,15 +657,20 @@ function _clip(poly::Vector{NTuple{2,S}}, i::Integer, c) where S
     if n == 1
         return poly[1][i] >= c ? poly : NTuple{2,S}[]
     end
+    if n == 2  # degenerate polygon: a segment
+        a, b = poly
+        ain, bin = a[i] >= c, b[i] >= c
+        ain && bin && return poly
+        !ain && !bin && return NTuple{2,S}[]
+        w = _intersection_point(a, b, i, c)
+        return ain ? [a, w] : [w, b]
+    end
     out = NTuple{2,S}[]
     for k in 1:n
         a, b = poly[k], poly[mod1(k+1, n)]
         a[i] >= c && push!(out, a)
         if (a[i] >= c) != (b[i] >= c)
-            t = (c - a[i]) / (b[i] - a[i])
-            w = i == 1 ? (S(c), a[2] + t*(b[2]-a[2])) :
-                         (a[1] + t*(b[1]-a[1]), S(c))
-            push!(out, w)
+            push!(out, _intersection_point(a, b, i, c))
         end
     end
     return out

--- a/src/repeated_game.jl
+++ b/src/repeated_game.jl
@@ -744,27 +744,29 @@ function _find_C(poly::Vector{NTuple{2,S}}, IC1, IC2, atol) where S
 end
 
 """
-    _R(rpd, best_dev_gains1, best_dev_gains2, poly, u, atol_in)
+    _R(delta, nums_actions, payoff_array1, payoff_array2,
+       best_dev_gains1, best_dev_gains2, poly, u, atol_in)
 
 Apply the R operator of Abreu and Sannikov (2014) once: collect, over all
 action profiles `a`, the candidate extreme points of the updated payoff set,
 namely the stage payoff `g(a)` itself if it is incentive compatible and in
 `poly`, and `(1-delta)g(a) + delta*w` for the points `w` of `poly` clipped
-to the IC region that lie on an IC boundary.
+to the IC region that lie on an IC boundary. The payoff arrays (and `u`,
+`poly`) are in the internal, centered coordinates set up by `AS`.
 
 Corresponds to `_R` in QuantEcon.py, with one difference: the IC-boundary
 points are collected also when `g(a)` itself is feasible (they are redundant
 in that case, and removed with the convex hull computation).
 """
-function _R(rpd::RepGame2, best_dev_gains1, best_dev_gains2,
+function _R(delta::S, nums_actions, payoff_array1, payoff_array2,
+            best_dev_gains1, best_dev_gains2,
             poly::Vector{NTuple{2,S}}, u, atol_in) where S
-    delta = convert(S, rpd.delta)
     v_new = NTuple{2,S}[]
-    sizehint!(v_new, 8 * prod(rpd.sg.nums_actions))
-    for a2 in 1:rpd.sg.nums_actions[2]
-        for a1 in 1:rpd.sg.nums_actions[1]
-            payoff1 = rpd.sg.players[1].payoff_array[a1, a2]
-            payoff2 = rpd.sg.players[2].payoff_array[a2, a1]
+    sizehint!(v_new, 8 * prod(nums_actions))
+    for a2 in 1:nums_actions[2]
+        for a1 in 1:nums_actions[1]
+            payoff1 = payoff_array1[a1, a2]
+            payoff2 = payoff_array2[a2, a1]
             IC1 = u[1] + best_dev_gains1[a1, a2]
             IC2 = u[2] + best_dev_gains2[a2, a1]
 
@@ -772,7 +774,7 @@ function _R(rpd::RepGame2, best_dev_gains1, best_dev_gains2,
             # first check if it satisfies IC,
             # then check if it is in the polygon
             if payoff1 > IC1 && payoff2 > IC2 &&
-                    _in_polygon((S(payoff1), S(payoff2)), poly, atol_in)
+                    _in_polygon((payoff1, payoff2), poly, atol_in)
                 push!(v_new, (payoff1, payoff2))
             end
 
@@ -837,7 +839,9 @@ julia> g = NormalFormGame(pd_payoff)  # symmetric 2-player game
 
 julia> rpd = RepeatedGame(g, 0.75);
 
-julia> vertices = AS(rpd; tol=1e-9)
+julia> vertices = AS(rpd; tol=1e-9);
+
+julia> round.(vertices, digits=6)  # vertices are accurate up to about tol
 4×2 Matrix{Float64}:
  3.0   3.0
  9.75  3.0
@@ -891,31 +895,57 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
         "`AS` no longer relies on a polyhedra library", :AS)
 
     S = _coefficient_type(rpd)
-    delta = rpd.delta
+    delta = convert(S, rpd.delta)
+
+    # Work with the payoff arrays in the coefficient type, with the payoffs
+    # of each player centered at zero when the payoff set is located far
+    # from the origin relative to its size. The floating point resolution
+    # and the geometric tolerances below then scale with the size of the
+    # payoff set rather than with its distance from the origin, making the
+    # computation robust to translations of the payoffs. The centers are
+    # added back to the output at the end. In exact arithmetic the centering
+    # has no effect on the result; near the origin it is skipped, as it is
+    # not needed there and would perturb the rounding of the common case.
+    extr1 = extrema(rpd.sg.players[1].payoff_array)
+    extr2 = extrema(rpd.sg.players[2].payoff_array)
+    magnitude = max(abs(convert(S, extr1[1])), abs(convert(S, extr1[2])),
+                    abs(convert(S, extr2[1])), abs(convert(S, extr2[2])))
+    spread = max(convert(S, extr1[2]) - convert(S, extr1[1]),
+                 convert(S, extr2[2]) - convert(S, extr2[1]))
+    center = magnitude > 4 * spread ?
+             [(convert(S, extr1[1]) + convert(S, extr1[2])) / 2,
+              (convert(S, extr2[1]) + convert(S, extr2[2])) / 2] :
+             [zero(S), zero(S)]
+    payoff_array1 = S.(rpd.sg.players[1].payoff_array) .- center[1]
+    payoff_array2 = S.(rpd.sg.players[2].payoff_array) .- center[2]
 
     # Initialize W0 with each entries of payoff bimatrix
     v_old = _payoff_points(S, rpd.sg)
+    v_old[:, 1] .-= center[1]
+    v_old[:, 2] .-= center[2]
 
-    mins = [minimum(rpd.sg.players[1].payoff_array),
-            minimum(rpd.sg.players[2].payoff_array)]
+    mins = [minimum(payoff_array1), minimum(payoff_array2)]
 
     if isnothing(u)
-        u = convert(Vector{S}, mins)
+        u = mins
     else
-        u = convert(Vector{S}, max.(u, mins))
+        u = max.(convert(Vector{S}, u) .- center, mins)
     end
 
     # calculate the best deviation gains
     # normalize with (1-delta)/delta
-    best_dev_gains1, best_dev_gains2 =
-        (one(S)-delta)/delta .* _best_dev_gains(rpd.sg)
+    best_dev_gains1 = (one(S)-delta)/delta .*
+        (maximum(payoff_array1, dims=1) .- payoff_array1)
+    best_dev_gains2 = (one(S)-delta)/delta .*
+        (maximum(payoff_array2, dims=1) .- payoff_array2)
 
     # Geometric tolerances, both zero (exact comparisons) in exact
     # arithmetic. `atol_merge` merges near-duplicate and near-collinear hull
     # vertices; `atol_in` is the slack for the membership and IC-boundary
     # tests and is coarser: for those predicates false negatives lose genuine
     # vertices of the equilibrium payoff set, while false positives only add
-    # redundant points of B(W), so err on the loose side.
+    # redundant points of B(W), so err on the loose side. With the payoffs
+    # centered, `payoff_scale` is half the size of the payoff set.
     payoff_scale = maximum(abs, v_old)
     scale = iszero(payoff_scale) ? one(S) : payoff_scale
     atol_merge = S <: AbstractFloat ? sqrt(eps(S)) * scale : zero(S)
@@ -929,7 +959,8 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
     for iter = 1:maxiter
 
         # step 1
-        v_new = _R(rpd, best_dev_gains1, best_dev_gains2, poly, u, atol_in)
+        v_new = _R(delta, rpd.sg.nums_actions, payoff_array1, payoff_array2,
+                   best_dev_gains1, best_dev_gains2, poly, u, atol_in)
 
         isempty(v_new) &&
             error("no incentive-compatible payoff vectors found: the game " *
@@ -970,10 +1001,11 @@ function AS(rpd::RepeatedGame{2,T,TD}; maxiter::Integer=1000,
         u = max.(u, u_)
     end
 
-    # Return matrix with coefficient type S
+    # Return matrix with coefficient type S, in the original coordinates
     vertices = Matrix{S}(undef, length(poly), 2)
     for (i, w) in enumerate(poly)
-        vertices[i, 1], vertices[i, 2] = w
+        vertices[i, 1] = w[1] + center[1]
+        vertices[i, 2] = w[2] + center[2]
     end
 
     return vertices

--- a/test/test_repeated_game.jl
+++ b/test/test_repeated_game.jl
@@ -127,7 +127,7 @@
             @test size(vertices) == size(pts_sorted)
         end
 
-        @testset "AS invariant to payoff translations" begin
+        @testset "AS is robust to large payoff translations" begin
             # The floating point tolerances must scale with the size of the
             # payoff set, not with its distance from the origin
             shift = (1e9, -2e9)

--- a/test/test_repeated_game.jl
+++ b/test/test_repeated_game.jl
@@ -127,6 +127,32 @@
             @test size(vertices) == size(pts_sorted)
         end
 
+        @testset "AS with degenerate payoff sets" begin
+            # Common interest game: all payoff pairs lie on the diagonal, so
+            # the payoff sets are segments; the equilibrium payoff set is
+            # the segment from (1, 1) to (4, 4)
+            c_payoff = [4.0 0.0; 0.0 1.0]
+            g_ci = NormalFormGame((Player(c_payoff), Player(c_payoff)))
+            for rpd_ci in (RepeatedGame(g_ci, 0.5),                     # Float64
+                           RepeatedGame(NormalFormGame(Int, g_ci), 1//2))  # exact
+                vertices = AS(rpd_ci; tol=1e-9)
+                @test vertices_match_expected(vertices, [1.0 1.0; 4.0 4.0])
+            end
+
+            # Constant game: the equilibrium payoff set is a single point
+            g_const = NormalFormGame((Player(fill(5.0, 2, 2)),
+                                      Player(fill(5.0, 2, 2))))
+            vertices = AS(RepeatedGame(g_const, 0.5); tol=1e-9)
+            @test vertices_match_expected(vertices, [5.0 5.0])
+        end
+
+        @testset "AS with empty payoff set" begin
+            # Matching pennies: no pure-action subgame perfect equilibrium
+            g_mp = NormalFormGame((Player([1.0 -1.0; -1.0 1.0]),
+                                   Player([-1.0 1.0; 1.0 -1.0])))
+            @test_throws ErrorException AS(RepeatedGame(g_mp, 0.5))
+        end
+
         @testset "uniquetolrows function" begin
             # Test the uniquetolrows utility function 
             V = [1.0001 2.0002; 1.0 2.0; 3.0 4.0; 1.00009 2.00008]

--- a/test/test_repeated_game.jl
+++ b/test/test_repeated_game.jl
@@ -127,6 +127,18 @@
             @test size(vertices) == size(pts_sorted)
         end
 
+        @testset "AS invariant to payoff translations" begin
+            # The floating point tolerances must scale with the size of the
+            # payoff set, not with its distance from the origin
+            shift = (1e9, -2e9)
+            g_shifted = NormalFormGame((Player(pd_payoff .+ shift[1]),
+                                        Player(pd_payoff .+ shift[2])))
+            vertices_shifted = @inferred(AS(RepeatedGame(g_shifted, 0.75);
+                                            tol=1e-9))
+            vertices_unshifted = vertices_shifted .- [shift[1] shift[2]]
+            @test vertices_match_expected(vertices_unshifted, pts_sorted)
+        end
+
         @testset "AS with degenerate payoff sets" begin
             # Common interest game: all payoff pairs lie on the diagonal, so
             # the payoff sets are segments; the equilibrium payoff set is


### PR DESCRIPTION
This PR rewrites the geometry inside `AS` to use direct 2D computational geometry instead of per-action-pair polyhedra-library calls, following up on the review discussion in #235. It contains two commits: the rewrite itself, and a restructuring that organizes the code to mirror the QuantEcon.py implementation.

## What changes

The candidate set W is maintained as a convex polygon (a counterclockwise vertex list). Each action pair clips it against the two IC half-planes (Sutherland–Hodgman), membership is tested with cross products, and redundant vertices are removed with a monotone-chain convex hull. All primitives use only field operations and comparisons, so the exact arithmetic path (`Rational{BigInt}`) is fully preserved. `outerapproximation` is unchanged.

The structure follows `quantecon.game_theory.repeated_game` in QuantEcon.py so the two implementations can be read side by side: `AS` is the driver, `_R` applies the R operator of Abreu and Sannikov (2014) once, and `_find_C` collects the IC-boundary points for one action profile. The intentional differences (clipping instead of an edge walk, which also handles degenerate segment- or point-shaped sets; IC-boundary points collected even when the stage payoff is feasible, keeping iterates identical to the previous implementation) are noted in the docstrings.

## Why

Profiling the previous implementation showed that 70–83% of the Float64 runtime went into the per-action-pair `polyhedron`/`intersect`/`vrep` pipeline (a full double-description conversion to cut a ≤8-vertex polygon with two axis-aligned lines) and much of the rest into the per-iteration rebuild with `removevredundancy!`; on the exact path with CDDLib, the rebuild alone was 71%. None of this is inherent to the algorithm — the problem is two-dimensional.

## Robustness

Floating-point behavior is governed by two explicit scale-based tolerances: `sqrt(eps)` for merging near-duplicate and near-collinear hull vertices (matching the accuracy of the previous output), and the coarser `cbrt(eps)` as slack for the membership and IC-boundary predicates, where false negatives lose genuine vertices of the equilibrium set while false positives only add redundant points of B(W). Vertex merging measures the distance to the segment joining the neighboring vertices, not to the line through them, which would erode true extreme points of degenerate sets. An empty candidate set now raises an informative error instead of crashing with a reduction over an empty collection.

## Verification

- The old and new implementations agree (Hausdorff distance below 1e-6) on the PD test games in all type combinations, on random 2x2, 3x3, 2x3, and 4x4 games, and on `randn` games with delta up to 0.9.
- In exact arithmetic the two implementations produce bit-identical iterates at fixed iteration counts.
- On one random 2x2 game with delta = 0.9, the previous implementation returns a strictly smaller set: against a converged 256-bit `BigFloat` reference, it is off by 2.1e-2 in Hausdorff distance while the new result agrees to 8.5e-14, so the rewrite fixes a genuine bug. (QuantEcon.py, given a correct `u_init`, also agrees with the reference on this game.)
- Degenerate (segment- or point-valued) equilibrium sets are handled; the previous CDDLib float path could also fail outright on such input (`ddf_DDMatrix2Poly: Numerically inconsistent`), and scipy/Qhull in QuantEcon.py raises `QhullError`.
- The full test suite passes, including the strengthened set-equality tests from #235.

## Performance (Apple Silicon, warm)

| | before | after |
|---|---|---|
| PD `Float64` | 4.4 ms | 0.31 ms |
| PD exact (`Rational{BigInt}`) | 102 ms | 23 ms |
| random 3x3 `Float64` | 7.7 ms | 1.5 ms |
| first call (incl. compilation) | 3.7 s | 1.2 s |
| `test_repeated_game.jl`, fresh process | 13.2 s | 7.9 s |

For reference, QuantEcon.py (Numba + Qhull) measures 1.8 ms / 0.9 ms on the same PD / 3x3 games.

## API notes

- The `plib` keyword argument of `AS` is deprecated and ignored (with a `depwarn`); `AS` no longer uses a polyhedra library. Passing it does not error, so existing code keeps running.
- The vertex row order of the returned matrix now follows the counterclockwise hull order (previously unspecified library order); the docstring examples are regenerated accordingly.

## Known limitation (pre-existing, now documented)

In exact arithmetic the rational coefficients can grow explosively with the iteration count on generic games (denominator digit counts roughly double per iteration; measured 14 digits at iteration 10 vs 13,841 at iteration 20 on a random 3x3 game, in both the old and new implementations). The docstring now notes this and suggests bounding `maxiter`; the PD example converges because its vertices stabilize to simple rationals.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
