### PR TITLE
DOC: Document the payoff array indexing convention

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,11 +18,16 @@ Once installed, the `GameTheory` package can be used by typing
 using GameTheory
 ```
 
+### Creating a game
+
 The Base type `Player` can be created by passing a payoff matrix:
 
 ```@example 1
 player1 = Player([3 1; 0 2])
 ```
+
+Here the rows of the payoff matrix correspond to player 1's own actions and
+the columns to the opponent's actions.
 
 A 2-player `NormalFormGame` can be created either by passing `Player` instances,
 
@@ -49,13 +54,42 @@ payoff_bimatrix[2, 2, :] = [2, 3]
 g = NormalFormGame(payoff_bimatrix)
 ```
 
-After constructing a `NormalFormGame`, we can find its Nash Equilibria by using methods of `GameTheory`. For example, `pure_nash` finds all pure action Nash Equilibria by enumeration:
+### Payoff array conventions
+
+Each player's `payoff_array` is indexed with the player's *own action first*:
+for player `i` in an N-player game, the first axis corresponds to player
+`i`'s own actions, and the `j`-th axis, `j = 2, ..., N`, to the actions of
+player `i+j-1` (modulo `N`). In the 2-player game `g` constructed above,
+
+```@example 1
+player1.payoff_array[1, 2] == 1 && player2.payoff_array[2, 1] == 1
+```
+
+both give the payoffs under the action profile in which player 1 plays
+action 1 and player 2 plays action 2 — each player's array is indexed with
+that player's own action first. Similarly, in a 3-player game,
+`g.players[2].payoff_array[a2, a3, a1]` is player 2's payoff under the
+action profile `(a1, a2, a3)`.
+
+### Computing Nash equilibria
+
+After constructing a `NormalFormGame`, we can find its Nash equilibria by
+using methods of `GameTheory`. For example, `pure_nash` finds all pure-action
+Nash equilibria by enumeration:
 
 ```@example 1
 pure_nash(g)
 ```
 
-Please see the [notebooks](@ref notebooks) on QuantEcon for more details.
+The game also has a mixed-action Nash equilibrium: `vertex_enumeration`
+finds all Nash equilibria of a two-player nondegenerate game, pure and mixed:
+
+```@example 1
+vertex_enumeration(g)
+```
+
+See [Computing Nash Equilibria](@ref computing_nash_equilibria) for the other
+solvers available.
 
 ## [Notebooks](@id notebooks)
 

--- a/src/normal_form_game.jl
+++ b/src/normal_form_game.jl
@@ -21,7 +21,11 @@ Type representing a player in an N-player normal form game.
 # Fields
 
 - `payoff_array::Array{T,N}` : Array representing the player's payoff function,
-  where `T<:Real`.
+  where `T<:Real`. The first axis corresponds to the player's own actions,
+  and the `j`-th axis, `j = 2, ..., N`, to the actions of the `(j-1)`-th
+  next opponent: `payoff_array[a_1, a_2, ..., a_N]` is the payoff to this
+  player when the player takes action `a_1` and the opponents take actions
+  `a_2, ..., a_N`, respectively.
 """
 struct Player{N,T<:Real}
     payoff_array::Array{T,N}
@@ -472,6 +476,13 @@ end
     NormalFormGame{N,T}
 
 Type representing an N-player normal form game.
+
+Each player's `payoff_array` is indexed with the player's own action first:
+in a game `g`, the payoff to player `i` when player `k` takes action `a_k`,
+`k = 1, ..., N`, is given by
+`g.players[i].payoff_array[a_i, a_{i+1}, ..., a_{i+N-1}]`, where the player
+indices are understood modulo `N`. That is, the `j`-th axis of player `i`'s
+`payoff_array` corresponds to the action of player `i+j-1` (mod `N`).
 
 # Fields
 


### PR DESCRIPTION
Closes #157.

The convention that a player's `payoff_array` is indexed with the player's own action first — and that in an N-player game the `j`-th axis of player `i`'s array corresponds to the action of player `i+j-1` (mod `N`) — was previously stated only in a notebook, as reported in #157. This PR states it explicitly in the documentation:

- **`Player` docstring**: the axis orientation — the first axis is the player's own actions, the `j`-th axis the actions of the `(j-1)`-th next opponent, with the `payoff_array[a_1, a_2, ..., a_N]` indexing spelled out.
- **`NormalFormGame` docstring**: the cross-player statement — the payoff to player `i` under action profile `(a_1, ..., a_N)` is `g.players[i].payoff_array[a_i, a_{i+1}, ..., a_{i+N-1}]`, indices modulo `N`.
- **Docs landing page**: the Usage section is restructured into subsections ("Creating a game", "Payoff array conventions", "Computing Nash equilibria"). The new conventions subsection includes a checkable example (`player1.payoff_array[1, 2] == 1 && player2.payoff_array[2, 1] == 1` for the same action profile) and a 3-player illustration. Also added: a mixed-action equilibrium example with `vertex_enumeration` (which returns clean rational-valued floats for this game), and a cross-reference to the Computing Nash Equilibria library page.

The docs build cleanly with Documenter, and all `@example` blocks execute with the outputs described.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)